### PR TITLE
Make JSDoc Highlight as Comments

### DIFF
--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+Cursor.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+Cursor.swift
@@ -12,6 +12,7 @@ extension TextViewController {
     /// Sets new cursor positions.
     /// - Parameter positions: The positions to set. Lines and columns are 1-indexed.
     public func setCursorPositions(_ positions: [CursorPosition]) {
+        if isPostingCursorNotification { return }
         _ = textView.becomeFirstResponder()
 
         var newSelectedRanges: [NSRange] = []
@@ -48,6 +49,9 @@ extension TextViewController {
             positions.append(CursorPosition(range: selectedRange.range, line: row, column: column))
         }
         cursorPositions = positions.sorted(by: { $0.range.location < $1.range.location })
+
+        isPostingCursorNotification = true
         NotificationCenter.default.post(name: Self.cursorPositionUpdatedNotification, object: nil)
+        isPostingCursorNotification = false
     }
 }

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -29,6 +29,8 @@ public class TextViewController: NSViewController {
     internal var highlightLayers: [CALayer] = []
     internal var systemAppearance: NSAppearance.Name?
 
+    package var isPostingCursorNotification: Bool = false
+
     /// The string contents.
     public var string: String {
         textView.string

--- a/Sources/CodeEditSourceEditor/Extensions/Tree+prettyPrint.swift
+++ b/Sources/CodeEditSourceEditor/Extensions/Tree+prettyPrint.swift
@@ -68,4 +68,65 @@ extension Tree {
         }
     }
 }
+
+extension MutableTree {
+    func prettyPrint() {
+        guard let cursor = self.rootNode?.treeCursor else {
+            print("NO ROOT NODE")
+            return
+        }
+        guard cursor.currentNode != nil else {
+            print("NO CURRENT NODE")
+            return
+        }
+
+        func p(_ cursor: TreeCursor, depth: Int) {
+            guard let node = cursor.currentNode else {
+                return
+            }
+
+            let visible = node.isNamed
+
+            if visible {
+                print(String(repeating: " ", count: depth * 2), terminator: "")
+                if let fieldName = cursor.currentFieldName {
+                    print(fieldName, ": ", separator: "", terminator: "")
+                }
+                print("(", node.nodeType ?? "NONE", " ", node.range, " ", separator: "", terminator: "")
+            }
+
+            if cursor.goToFirstChild() {
+                while true {
+                    if cursor.currentNode != nil && cursor.currentNode!.isNamed {
+                        print("")
+                    }
+
+                    p(cursor, depth: depth + 1)
+
+                    if !cursor.gotoNextSibling() {
+                        break
+                    }
+                }
+
+                if !cursor.gotoParent() {
+                    fatalError("Could not go to parent, this tree may be invalid.")
+                }
+            }
+
+            if visible {
+                print(")", terminator: "")
+            }
+        }
+
+        if cursor.currentNode?.childCount == 0 {
+            if !cursor.currentNode!.isNamed {
+                print("{\(cursor.currentNode!.nodeType ?? "NONE")}")
+            } else {
+                print("\"\(cursor.currentNode!.nodeType ?? "NONE")\"")
+            }
+        } else {
+            p(cursor, depth: 1)
+        }
+    }
+}
 #endif

--- a/Sources/CodeEditSourceEditor/TreeSitter/TreeSitterClient+Highlight.swift
+++ b/Sources/CodeEditSourceEditor/TreeSitter/TreeSitterClient+Highlight.swift
@@ -67,6 +67,7 @@ extension TreeSitterClient {
 
         var highlights: [HighlightRange] = []
 
+        // See https://github.com/CodeEditApp/CodeEditSourceEditor/pull/228
         if layer.id == .jsdoc {
             highlights.append(HighlightRange(range: range, capture: .comment))
         }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Makes JSDocs highlight as comments. Because they're injected as a different language they don't get captured normally. This is the only language we have to handle this in so it's hard-coded in the TreeSitterClient.

Also adds a quick check to prevent potential recursive cursor notifications using SwiftUI.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* [Discord conversation](https://canary.discord.com/channels/951544472238444645/987416899816149024/1201620579590090853)

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<img width="285" alt="Screenshot 2024-02-02 at 7 37 19 PM" src="https://github.com/CodeEditApp/CodeEditSourceEditor/assets/35942988/f201e5ff-1bf9-4bb5-97fb-0914aa66246a">
