### PR TITLE
Correctly Lose Focus (finish CETV#14)

### DIFF
--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+Cursor.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+Cursor.swift
@@ -13,8 +13,6 @@ extension TextViewController {
     /// - Parameter positions: The positions to set. Lines and columns are 1-indexed.
     public func setCursorPositions(_ positions: [CursorPosition]) {
         if isPostingCursorNotification { return }
-        _ = textView.becomeFirstResponder()
-
         var newSelectedRanges: [NSRange] = []
         for position in positions {
             let line = position.line
@@ -48,9 +46,9 @@ extension TextViewController {
             let row = linePosition.index + 1
             positions.append(CursorPosition(range: selectedRange.range, line: row, column: column))
         }
-        cursorPositions = positions.sorted(by: { $0.range.location < $1.range.location })
 
         isPostingCursorNotification = true
+        cursorPositions = positions.sorted(by: { $0.range.location < $1.range.location })
         NotificationCenter.default.post(name: Self.cursorPositionUpdatedNotification, object: nil)
         isPostingCursorNotification = false
     }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Finishes the required changes to make [CodeEditTextView#14](https://github.com/CodeEditApp/CodeEditTextView/pull/14) work in CESE, once those changes are merged with a package update.

Removes the first responder acquisition when updating cursors, the text view should handle focus state and does so correctly on the main branch. Also fixes a small ordering bug with a check variable related to this issue.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* CodeEditTextView issue, no issues created here.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A