### PR TITLE
(fix:#227) Apply Theme Selection Color

### DIFF
--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
@@ -14,7 +14,6 @@ extension TextViewController {
         scrollView = NSScrollView()
         textView.postsFrameChangedNotifications = true
         textView.translatesAutoresizingMaskIntoConstraints = false
-        textView.selectionManager.insertionPointColor = theme.insertionPoint
 
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.contentView.postsFrameChangedNotifications = true
@@ -22,7 +21,6 @@ extension TextViewController {
         scrollView.hasHorizontalScroller = true
         scrollView.documentView = textView
         scrollView.contentView.postsBoundsChangedNotifications = true
-        scrollView.backgroundColor = useThemeBackground ? theme.background : .clear
         if let contentInsets {
             scrollView.automaticallyAdjustsContentInsets = false
             scrollView.contentInsets = contentInsets
@@ -35,7 +33,6 @@ extension TextViewController {
             delegate: self
         )
         gutterView.frame.origin.y = -scrollView.contentInsets.top
-        gutterView.backgroundColor = useThemeBackground ? theme.background : .textBackgroundColor
         gutterView.updateWidthIfNeeded()
         scrollView.addFloatingSubview(
             gutterView,
@@ -46,6 +43,10 @@ extension TextViewController {
         if let _undoManager {
             textView.setUndoManager(_undoManager)
         }
+
+        styleTextView()
+        styleGutterView()
+        styleScrollView()
         setUpHighlighter()
         setUpTextFormation()
 

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -59,6 +59,7 @@ public class TextViewController: NSViewController {
                 attributesFor(nil),
                 range: NSRange(location: 0, length: textView.textStorage.length)
             )
+            textView.selectionManager.selectedLineBackgroundColor = theme.selection
             highlighter?.invalidate()
         }
     }
@@ -263,16 +264,39 @@ public class TextViewController: NSViewController {
         textView.isEditable = isEditable
         textView.isSelectable = isSelectable
 
+        styleTextView()
+        styleGutterView()
+        styleScrollView()
+
+        highlighter?.invalidate()
+    }
+
+    /// Style the text view.
+    package func styleTextView() {
         textView.selectionManager.selectionBackgroundColor = theme.selection
-        textView.selectionManager.selectedLineBackgroundColor = useThemeBackground
-        ? theme.lineHighlight
-        : systemAppearance == .darkAqua
-        ? NSColor.quaternaryLabelColor : NSColor.selectedTextBackgroundColor.withSystemEffect(.disabled)
+        textView.selectionManager.selectedLineBackgroundColor = getThemeBackground()
         textView.selectionManager.highlightSelectedLine = isEditable
         textView.selectionManager.insertionPointColor = theme.insertionPoint
         paragraphStyle = generateParagraphStyle()
         textView.typingAttributes = attributesFor(nil)
+    }
 
+    /// Finds the preferred use theme background.
+    /// - Returns: The background color to use.
+    private func getThemeBackground() -> NSColor {
+        if useThemeBackground {
+            return theme.lineHighlight
+        }
+
+        if systemAppearance == .darkAqua {
+            return NSColor.quaternaryLabelColor
+        }
+
+        return NSColor.selectedTextBackgroundColor.withSystemEffect(.disabled)
+    }
+
+    /// Style the gutter view.
+    package func styleGutterView() {
         gutterView.selectedLineColor = useThemeBackground ? theme.lineHighlight : systemAppearance == .darkAqua
         ? NSColor.quaternaryLabelColor
         : NSColor.selectedTextBackgroundColor.withSystemEffect(.disabled)
@@ -283,17 +307,17 @@ public class TextViewController: NSViewController {
             gutterView.selectedLineTextColor = nil
             gutterView.selectedLineColor = .clear
         }
+    }
 
-        if let scrollView = view as? NSScrollView {
-            scrollView.drawsBackground = useThemeBackground
-            scrollView.backgroundColor = useThemeBackground ? theme.background : .clear
-            if let contentInsets = contentInsets {
-                scrollView.contentInsets = contentInsets
-            }
-            scrollView.contentInsets.bottom = (contentInsets?.bottom ?? 0) + bottomContentInsets
+    /// Style the scroll view.
+    package func styleScrollView() {
+        guard let scrollView = view as? NSScrollView else { return }
+        scrollView.drawsBackground = useThemeBackground
+        scrollView.backgroundColor = useThemeBackground ? theme.background : .clear
+        if let contentInsets = contentInsets {
+            scrollView.contentInsets = contentInsets
         }
-
-        highlighter?.invalidate()
+        scrollView.contentInsets.bottom = (contentInsets?.bottom ?? 0) + bottomContentInsets
     }
 
     deinit {


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Fixes some theme colors not applying when the editor is first opened. 

Moved configuration to 3 methods, one for the textview, gutter, and scroll view respectively. These functions are used in both the `reloadUI` and `loadView` methods to ensure it's consistent in both initial loads and reloading.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #227 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEditSourceEditor/assets/35942988/71ea08df-c44c-425f-8cdb-280fd693f56b
