### PR TITLE
Update Gutter Drawing Code

### DIFF
--- a/Sources/CodeEditSourceEditor/Gutter/GutterView.swift
+++ b/Sources/CodeEditSourceEditor/Gutter/GutterView.swift
@@ -7,6 +7,7 @@
 
 import AppKit
 import CodeEditTextView
+import CodeEditTextViewObjC
 
 public protocol GutterViewDelegate: AnyObject {
     func gutterViewWidthDidUpdate(newWidth: CGFloat)
@@ -55,10 +56,6 @@ public class GutterView: NSView {
         true
     }
 
-    override public var wantsDefaultClipping: Bool {
-        false
-    }
-
     public init(
         font: NSFont,
         textColor: NSColor,
@@ -71,11 +68,11 @@ public class GutterView: NSView {
         self.delegate = delegate
 
         super.init(frame: .zero)
-        clipsToBounds = false
+        clipsToBounds = true
         wantsLayer = true
         layerContentsRedrawPolicy = .onSetNeedsDisplay
         translatesAutoresizingMaskIntoConstraints = false
-        layer?.masksToBounds = false
+        layer?.masksToBounds = true
 
         NotificationCenter.default.addObserver(
             forName: TextSelectionManager.selectionChangedNotification,
@@ -165,6 +162,16 @@ public class GutterView: NSView {
         }
 
         context.saveGState()
+
+        context.setAllowsAntialiasing(true)
+        context.setShouldAntialias(true)
+        context.setAllowsFontSmoothing(false)
+        context.setAllowsFontSubpixelPositioning(true)
+        context.setShouldSubpixelPositionFonts(true)
+        context.setAllowsFontSubpixelQuantization(true)
+        context.setShouldSubpixelQuantizeFonts(true)
+        ContextSetHiddenSmoothingStyle(context, 16)
+
         context.textMatrix = CGAffineTransform(scaleX: 1, y: -1)
         for linePosition in textView.layoutManager.visibleLines() {
             if selectionRangeMap.intersects(integersIn: linePosition.range) {


### PR DESCRIPTION
### Description

Updates gutter line number drawing to use the same settings as CETV in [this PR](https://github.com/CodeEditApp/CodeEditTextView/pull/23).

### Related Issues

N/A

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
