### PR TITLE
(fix: #233) Fix TextFormation editing

### DIFF
--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "6653c21a603babf365a12d4d331fadc8f8b52d99",
-        "version" : "0.7.2"
+        "revision" : "86b980464bcb67693e2053283c7a99bdc6f358bc",
+        "version" : "0.7.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         // A fast, efficient, text view for code.
         .package(
             url: "https://github.com/CodeEditApp/CodeEditTextView.git",
-            from: "0.7.2"
+            from: "0.7.3"
         ),
         // tree-sitter languages
         .package(

--- a/Sources/CodeEditSourceEditor/Extensions/TextMutation+isEmpty.swift
+++ b/Sources/CodeEditSourceEditor/Extensions/TextMutation+isEmpty.swift
@@ -1,0 +1,17 @@
+//
+//  TextMutation+isEmpty.swift
+//  CodeEditSourceEditor
+//
+//  Created by Khan Winter on 3/1/24.
+//
+
+import TextStory
+
+extension TextMutation {
+    /// Determines if the mutation is an empty mutation.
+    ///
+    /// Will return `true` if the mutation is neither a delete operation nor an insert operation.
+    var isEmpty: Bool {
+        self.string.isEmpty && self.range.isEmpty
+    }
+}

--- a/Sources/CodeEditSourceEditor/Extensions/TextView+/TextView+TextFormation.swift
+++ b/Sources/CodeEditSourceEditor/Extensions/TextView+/TextView+TextFormation.swift
@@ -38,12 +38,6 @@ extension TextView: TextInterface {
         layoutManager.beginTransaction()
         textStorage.beginEditing()
 
-        var wasGrouping = true
-        if !(_undoManager?.isGrouping ?? false) {
-            _undoManager?.beginGrouping()
-            wasGrouping = false
-        }
-
         layoutManager.willReplaceCharactersInRange(range: mutation.range, with: mutation.string)
         _undoManager?.registerMutation(mutation)
         textStorage.replaceCharacters(in: mutation.range, with: mutation.string)
@@ -52,9 +46,6 @@ extension TextView: TextInterface {
             replacementLength: (mutation.string as NSString).length
         )
 
-        if !wasGrouping {
-            _undoManager?.endGrouping()
-        }
         textStorage.endEditing()
         layoutManager.endTransaction()
     }

--- a/Sources/CodeEditSourceEditor/Extensions/TextView+/TextView+TextFormation.swift
+++ b/Sources/CodeEditSourceEditor/Extensions/TextView+/TextView+TextFormation.swift
@@ -33,8 +33,13 @@ extension TextView: TextInterface {
     }
 
     /// Applies the mutation to the text view.
+    ///
+    /// If the mutation is empty it will be ignored.
+    ///
     /// - Parameter mutation: The mutation to apply.
     public func applyMutation(_ mutation: TextMutation) {
+        guard !mutation.isEmpty else { return }
+
         layoutManager.beginTransaction()
         textStorage.beginEditing()
 

--- a/Sources/CodeEditSourceEditor/Extensions/TextView+/TextView+TextFormation.swift
+++ b/Sources/CodeEditSourceEditor/Extensions/TextView+/TextView+TextFormation.swift
@@ -37,7 +37,12 @@ extension TextView: TextInterface {
     public func applyMutation(_ mutation: TextMutation) {
         layoutManager.beginTransaction()
         textStorage.beginEditing()
-        _undoManager?.beginGrouping()
+
+        var wasGrouping = true
+        if !(_undoManager?.isGrouping ?? false) {
+            _undoManager?.beginGrouping()
+            wasGrouping = false
+        }
 
         layoutManager.willReplaceCharactersInRange(range: mutation.range, with: mutation.string)
         _undoManager?.registerMutation(mutation)
@@ -47,7 +52,9 @@ extension TextView: TextInterface {
             replacementLength: (mutation.string as NSString).length
         )
 
-        _undoManager?.endGrouping()
+        if !wasGrouping {
+            _undoManager?.endGrouping()
+        }
         textStorage.endEditing()
         layoutManager.endTransaction()
     }

--- a/Sources/CodeEditSourceEditor/Extensions/TextView+/TextView+TextFormation.swift
+++ b/Sources/CodeEditSourceEditor/Extensions/TextView+/TextView+TextFormation.swift
@@ -35,11 +35,20 @@ extension TextView: TextInterface {
     /// Applies the mutation to the text view.
     /// - Parameter mutation: The mutation to apply.
     public func applyMutation(_ mutation: TextMutation) {
+        layoutManager.beginTransaction()
+        textStorage.beginEditing()
+        _undoManager?.beginGrouping()
+
         layoutManager.willReplaceCharactersInRange(range: mutation.range, with: mutation.string)
+        _undoManager?.registerMutation(mutation)
+        textStorage.replaceCharacters(in: mutation.range, with: mutation.string)
         selectionManager.didReplaceCharacters(
             in: mutation.range,
             replacementLength: (mutation.string as NSString).length
         )
-        textStorage.replaceCharacters(in: mutation.range, with: mutation.string)
+
+        _undoManager?.endGrouping()
+        textStorage.endEditing()
+        layoutManager.endTransaction()
     }
 }

--- a/Sources/CodeEditSourceEditor/Filters/TabReplacementFilter.swift
+++ b/Sources/CodeEditSourceEditor/Filters/TabReplacementFilter.swift
@@ -20,9 +20,13 @@ struct TabReplacementFilter: Filter {
         with providers: WhitespaceProviders
     ) -> FilterAction {
         if mutation.string == "\t" && indentOption != .tab && mutation.delta > 0 {
-            interface.applyMutation(TextMutation(insert: indentOption.stringValue,
-                                                 at: mutation.range.location,
-                                                 limit: mutation.limit))
+            interface.applyMutation(
+                TextMutation(
+                    insert: indentOption.stringValue,
+                    at: mutation.range.location,
+                    limit: mutation.limit
+                )
+            )
             return .discard
         } else {
             return .none


### PR DESCRIPTION
### Description

- Cleans up undo/redo operations when TextFormation is activated, for instance when inserting or deleting a newline.

> ~Note: Requires [CodeEditTextView#25](https://github.com/CodeEditApp/CodeEditTextView/pull/25) to be merged.~ Merged!

### Related Issues

* closes #233

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEditSourceEditor/assets/35942988/d842b77d-60b4-4afd-be6c-2fb3d0342c4c

