### PR TITLE
Update GutterView Insets Correctly

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "6653c21a603babf365a12d4d331fadc8f8b52d99",
-        "version" : "0.7.2"
+        "revision" : "86b980464bcb67693e2053283c7a99bdc6f358bc",
+        "version" : "0.7.3"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/TextFormation",
       "state" : {
-        "revision" : "b4987856bc860643ac2c9cdbc7d5f3e9ade68377",
-        "version" : "0.8.1"
+        "revision" : "f6faed6abd768ae95b70d10113d4008a7cac57a7",
+        "version" : "0.8.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // Rules for indentation, pair completion, whitespace
         .package(
             url: "https://github.com/ChimeHQ/TextFormation",
-            from: "0.8.1"
+            from: "0.8.2"
         )
     ],
     targets: [

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
@@ -21,10 +21,6 @@ extension TextViewController {
         scrollView.hasHorizontalScroller = true
         scrollView.documentView = textView
         scrollView.contentView.postsBoundsChangedNotifications = true
-        if let contentInsets {
-            scrollView.automaticallyAdjustsContentInsets = false
-            scrollView.contentInsets = contentInsets
-        }
 
         gutterView = GutterView(
             font: font.rulerFont,
@@ -32,7 +28,6 @@ extension TextViewController {
             textView: textView,
             delegate: self
         )
-        gutterView.frame.origin.y = -scrollView.contentInsets.top
         gutterView.updateWidthIfNeeded()
         scrollView.addFloatingSubview(
             gutterView,
@@ -45,8 +40,8 @@ extension TextViewController {
         }
 
         styleTextView()
-        styleGutterView()
         styleScrollView()
+        styleGutterView()
         setUpHighlighter()
         setUpTextFormation()
 

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -264,9 +264,9 @@ public class TextViewController: NSViewController {
         textView.isEditable = isEditable
         textView.isSelectable = isSelectable
 
+        styleScrollView()
         styleTextView()
         styleGutterView()
-        styleScrollView()
 
         highlighter?.invalidate()
     }
@@ -297,6 +297,7 @@ public class TextViewController: NSViewController {
 
     /// Style the gutter view.
     package func styleGutterView() {
+        gutterView.frame.origin.y = -scrollView.contentInsets.top
         gutterView.selectedLineColor = useThemeBackground ? theme.lineHighlight : systemAppearance == .darkAqua
         ? NSColor.quaternaryLabelColor
         : NSColor.selectedTextBackgroundColor.withSystemEffect(.disabled)
@@ -314,8 +315,11 @@ public class TextViewController: NSViewController {
         guard let scrollView = view as? NSScrollView else { return }
         scrollView.drawsBackground = useThemeBackground
         scrollView.backgroundColor = useThemeBackground ? theme.background : .clear
-        if let contentInsets = contentInsets {
+        if let contentInsets {
+            scrollView.automaticallyAdjustsContentInsets = false
             scrollView.contentInsets = contentInsets
+        } else {
+            scrollView.automaticallyAdjustsContentInsets = true
         }
         scrollView.contentInsets.bottom = (contentInsets?.bottom ?? 0) + bottomContentInsets
     }

--- a/Tests/CodeEditSourceEditorTests/TextViewControllerTests.swift
+++ b/Tests/CodeEditSourceEditorTests/TextViewControllerTests.swift
@@ -112,10 +112,12 @@ final class TextViewControllerTests: XCTestCase {
 
     func test_editorInsets() throws {
         let scrollView = try XCTUnwrap(controller.view as? NSScrollView)
-        scrollView.frame = .init(x: .zero,
-                                 y: .zero,
-                                 width: 100,
-                                 height: 100)
+        scrollView.frame = .init(
+            x: .zero,
+            y: .zero,
+            width: 100,
+            height: 100
+        )
 
         func assertInsetsEqual(_ lhs: NSEdgeInsets, _ rhs: NSEdgeInsets) throws {
             XCTAssertEqual(lhs.top, rhs.top)
@@ -130,18 +132,21 @@ final class TextViewControllerTests: XCTestCase {
 
         // contentInsets: 0
         try assertInsetsEqual(scrollView.contentInsets, NSEdgeInsets(top: 0, left: 0, bottom: 0, right: 0))
+        XCTAssertEqual(controller.gutterView.frame.origin.y, 0)
 
         // contentInsets: 16
         controller.contentInsets = NSEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
         controller.reloadUI()
 
         try assertInsetsEqual(scrollView.contentInsets, NSEdgeInsets(top: 16, left: 16, bottom: 16, right: 16))
+        XCTAssertEqual(controller.gutterView.frame.origin.y, -16)
 
         // contentInsets: different
         controller.contentInsets = NSEdgeInsets(top: 32.5, left: 12.3, bottom: 20, right: 1)
         controller.reloadUI()
 
         try assertInsetsEqual(scrollView.contentInsets, NSEdgeInsets(top: 32.5, left: 12.3, bottom: 20, right: 1))
+        XCTAssertEqual(controller.gutterView.frame.origin.y, -32.5)
 
         // contentInsets: 16
         // editorOverscroll: 0.5
@@ -150,6 +155,7 @@ final class TextViewControllerTests: XCTestCase {
         controller.reloadUI()
 
         try assertInsetsEqual(scrollView.contentInsets, NSEdgeInsets(top: 16, left: 16, bottom: 16 + 50, right: 16))
+        XCTAssertEqual(controller.gutterView.frame.origin.y, -16)
     }
 
     func test_editorOverScroll_ZeroCondition() throws {


### PR DESCRIPTION
### Description

- Refactors a few style functions to correctly update the gutter view's position when the content insets change.
- Adds the gutter view position to the content insets test case.

### Related Issues

* Required to finish [CodeEdit#1603](https://github.com/CodeEditApp/CodeEdit/pull/1603)

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A