### PR TITLE
Make font weights more aligned with Xcode

### DIFF
--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+Highlighter.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+Highlighter.swift
@@ -48,7 +48,8 @@ extension TextViewController: ThemeAttributesProviding {
         [
             .font: font,
             .foregroundColor: theme.colorFor(capture),
-            .kern: textView.kern
+            .kern: textView.kern,
+            .strokeWidth: theme.widthFor(capture),
         ]
     }
 }

--- a/Sources/CodeEditSourceEditor/Theme/EditorTheme.swift
+++ b/Sources/CodeEditSourceEditor/Theme/EditorTheme.swift
@@ -82,6 +82,15 @@ public struct EditorTheme {
         default: return text
         }
     }
+
+    func widthFor(_ capture: CaptureName?) -> Float {
+        switch capture {
+        case .include, .constructor, .keyword, .boolean, .variableBuiltin,
+                .keywordReturn, .keywordFunction, .repeat, .conditional, .tag, .type:
+            return -4.0
+        default: return 0.0
+        }
+    }
 }
 
 extension EditorTheme: Equatable {

--- a/Sources/CodeEditSourceEditor/Theme/EditorTheme.swift
+++ b/Sources/CodeEditSourceEditor/Theme/EditorTheme.swift
@@ -83,11 +83,14 @@ public struct EditorTheme {
         }
     }
 
+    /// Gets the `strokeWidth` for the specified capture name.
+    /// - Parameter capture: The capture name
+    /// - Returns: a float representing `strokeWidth`
     func widthFor(_ capture: CaptureName?) -> Float {
         switch capture {
         case .include, .constructor, .keyword, .boolean, .variableBuiltin,
                 .keywordReturn, .keywordFunction, .repeat, .conditional, .tag, .type:
-            return -4.0
+            return -3.0
         default: return 0.0
         }
     }

--- a/Sources/CodeEditSourceEditor/Theme/EditorTheme.swift
+++ b/Sources/CodeEditSourceEditor/Theme/EditorTheme.swift
@@ -89,8 +89,8 @@ public struct EditorTheme {
     func widthFor(_ capture: CaptureName?) -> Float {
         switch capture {
         case .include, .constructor, .keyword, .boolean, .variableBuiltin,
-                .keywordReturn, .keywordFunction, .repeat, .conditional, .tag, .type:
-            return -3.0
+                .keywordReturn, .keywordFunction, .repeat, .conditional, .tag:
+            return -5.0
         default: return 0.0
         }
     }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
This PR makes CodeEdit's font weights align more with XCode's.

Before:
<img width="517" alt="image" src="https://github.com/CodeEditApp/CodeEditSourceEditor/assets/65467530/e88061c7-f994-4195-81e3-5013b202abd3">

After:
<img width="563" alt="image" src="https://github.com/CodeEditApp/CodeEditSourceEditor/assets/65467530/e2337274-d1ad-4a78-9fe6-d578cbe60e7c">

XCode:
<img width="392" alt="image" src="https://github.com/CodeEditApp/CodeEditSourceEditor/assets/65467530/9ef70418-ee0f-48de-b0f0-5f395079f8f3">


This PR notably lacks support for specifying customs weights in the theme file, and instead hardcodes weights based on symbol for the time being; I'm open to either working on supporting theme file now or after this PR is merged :)

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* Closes https://github.com/CodeEditApp/CodeEdit/issues/1686

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
