### PR TITLE
autocomplete tags/components

### DIFF
--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+TextFormation.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+TextFormation.swift
@@ -92,7 +92,16 @@ extension TextViewController {
     }
 
     private func setUpTagFiler() {
-        textFilters.append(TagFilter())
+        let filter = TagFilter(language: self.language.tsName)
+        textFilters.append(filter)
+    }
+
+    func updateTagFilter() {
+        // Remove existing TagFilter if present
+        textFilters.removeAll { $0 is TagFilter }
+
+        // Add new TagFilter with the updated language
+        textFilters.append(TagFilter(language: self.language.tsName))
     }
 
     /// Determines whether or not a text mutation should be applied.

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+TextFormation.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+TextFormation.swift
@@ -40,7 +40,7 @@ extension TextViewController {
         setUpNewlineTabFilters(indentOption: indentOption)
         setUpDeletePairFilters(pairs: BracketPairs.allValues)
         setUpDeleteWhitespaceFilter(indentOption: indentOption)
-        setUpTagFiler()
+        setUpTagFilter()
     }
 
     /// Returns a `TextualIndenter` based on available language configuration.
@@ -91,7 +91,7 @@ extension TextViewController {
         textFilters.append(filter)
     }
 
-    private func setUpTagFiler() {
+    private func setUpTagFilter() {
         let filter = TagFilter(language: self.language.tsName)
         textFilters.append(filter)
     }

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+TextFormation.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+TextFormation.swift
@@ -40,6 +40,7 @@ extension TextViewController {
         setUpNewlineTabFilters(indentOption: indentOption)
         setUpDeletePairFilters(pairs: BracketPairs.allValues)
         setUpDeleteWhitespaceFilter(indentOption: indentOption)
+        setUpTagFiler()
     }
 
     /// Returns a `TextualIndenter` based on available language configuration.
@@ -88,6 +89,10 @@ extension TextViewController {
     private func setUpDeleteWhitespaceFilter(indentOption: IndentOption) {
         let filter = DeleteWhitespaceFilter(indentOption: indentOption)
         textFilters.append(filter)
+    }
+
+    private func setUpTagFiler() {
+        textFilters.append(TagFilter())
     }
 
     /// Determines whether or not a text mutation should be applied.

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+TextFormation.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+TextFormation.swift
@@ -97,10 +97,9 @@ extension TextViewController {
     }
 
     func updateTagFilter() {
-        // Remove existing TagFilter if present
         textFilters.removeAll { $0 is TagFilter }
 
-        // Add new TagFilter with the updated language
+        // Add new tagfilter with the updated language
         textFilters.append(TagFilter(language: self.language.tsName))
     }
 
@@ -124,15 +123,30 @@ extension TextViewController {
         )
 
         for filter in textFilters {
-            let action = filter.processMutation(mutation, in: textView, with: whitespaceProvider)
-
-            switch action {
-            case .none:
-                break
-            case .stop:
-                return true
-            case .discard:
-                return false
+            if let newlineFilter = filter as? NewlineProcessingFilter {
+                let action = mutation.applyWithTagProcessing(
+                    in: textView,
+                    using: newlineFilter,
+                    with: whitespaceProvider, indentOption: indentOption
+                )
+                switch action {
+                case .none:
+                    continue
+                case .stop:
+                    return true
+                case .discard:
+                    return false
+                }
+            } else {
+                let action = filter.processMutation(mutation, in: textView, with: whitespaceProvider)
+                switch action {
+                case .none:
+                    continue
+                case .stop:
+                    return true
+                case .discard:
+                    return false
+                }
             }
         }
 

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -39,6 +39,7 @@ public class TextViewController: NSViewController {
     public var language: CodeLanguage {
         didSet {
             highlighter?.setLanguage(language: language)
+            updateTagFilter()
         }
     }
 

--- a/Sources/CodeEditSourceEditor/Extensions/NewlineProcessingFilter+TagHandling.swift
+++ b/Sources/CodeEditSourceEditor/Extensions/NewlineProcessingFilter+TagHandling.swift
@@ -1,0 +1,102 @@
+//
+//  NewlineProcessingFilter+TagHandling.swift
+//  CodeEditSourceEditor
+//
+//  Created by Roscoe Rubin-Rottenberg on 5/19/24.
+//
+
+import Foundation
+import TextStory
+import TextFormation
+
+extension NewlineProcessingFilter {
+
+    private func handleTags(
+        for mutation: TextMutation,
+        in interface: TextInterface,
+        with indentOption: IndentOption
+    ) -> Bool {
+        guard let precedingText = interface.substring(
+            from: NSRange(
+                location: 0,
+                length: mutation.range.location
+            )
+        ) else {
+            return false
+        }
+
+        guard let followingText = interface.substring(
+                from: NSRange(
+                    location: mutation.range.location,
+                    length: interface.length - mutation.range.location
+                )
+              ) else {
+            return false
+        }
+
+        let tagPattern = "<([a-zA-Z][a-zA-Z0-9]*)\\b[^>]*>"
+
+        guard let precedingTagGroups = precedingText.groups(for: tagPattern),
+              let precedingTag = precedingTagGroups.first else {
+            return false
+        }
+
+        guard followingText.range(of: "</\(precedingTag)>", options: .regularExpression) != nil else {
+            return false
+        }
+
+        let insertionLocation = mutation.range.location
+        let newline = "\n"
+        let indentedNewline = newline + indentOption.stringValue
+        let newRange = NSRange(location: insertionLocation + indentedNewline.count, length: 0)
+
+        // Insert indented newline first
+        interface.insertString(indentedNewline, at: insertionLocation)
+        // Then insert regular newline after indented newline
+        interface.insertString(newline, at: insertionLocation + indentedNewline.count)
+        interface.selectedRange = newRange
+
+        return true
+    }
+
+    public func processTags(
+        for mutation: TextMutation,
+        in interface: TextInterface,
+        with indentOption: IndentOption
+    ) -> FilterAction {
+        if handleTags(for: mutation, in: interface, with: indentOption) {
+            return .discard
+        }
+        return .none
+    }
+}
+
+public extension TextMutation {
+    func applyWithTagProcessing(
+        in interface: TextInterface,
+        using filter: NewlineProcessingFilter,
+        with providers: WhitespaceProviders,
+        indentOption: IndentOption
+    ) -> FilterAction {
+        if filter.processTags(for: self, in: interface, with: indentOption) == .discard {
+            return .discard
+        }
+
+        // Apply the original filter processing
+        return filter.processMutation(self, in: interface, with: providers)
+    }
+}
+
+// Helper extension to extract capture groups
+extension String {
+    func groups(for regexPattern: String) -> [String]? {
+        guard let regex = try? NSRegularExpression(pattern: regexPattern) else { return nil }
+        let nsString = self as NSString
+        let results = regex.matches(in: self, range: NSRange(location: 0, length: nsString.length))
+        return results.first.map { result in
+            (1..<result.numberOfRanges).compactMap {
+                result.range(at: $0).location != NSNotFound ? nsString.substring(with: result.range(at: $0)) : nil
+            }
+        }
+    }
+}

--- a/Sources/CodeEditSourceEditor/Filters/TagFilter.swift
+++ b/Sources/CodeEditSourceEditor/Filters/TagFilter.swift
@@ -25,10 +25,10 @@ struct TagFilter: Filter {
         let insertedText = mutation.string
         let fullText = interface.string
 
-        // Check if the inserted text is a closing bracket '>'
+        // Check if the inserted text is a closing bracket (>)
         if insertedText == ">" {
             let textBeforeCursor = "\(String(fullText[..<range.lowerBound]))\(insertedText)"
-            if let lastOpenTag = textBeforeCursor.lastTag {
+            if let lastOpenTag = textBeforeCursor.nearestTag {
                 // Check if the tag is not self-closing and there isn't already a closing tag
                 if !lastOpenTag.isSelfClosing && !textBeforeCursor.contains("</\(lastOpenTag.name)>") {
                     let closingTag = "</\(lastOpenTag.name)>"
@@ -51,13 +51,13 @@ struct TagFilter: Filter {
     }
 }
 private extension String {
-    var lastTag: (name: String, isSelfClosing: Bool)? {
-        // Regex to find the last tag
+    var nearestTag: (name: String, isSelfClosing: Bool)? {
         let regex = try? NSRegularExpression(pattern: "<([a-zA-Z0-9]+)([^>]*)>", options: .caseInsensitive)
         let nsString = self as NSString
         let results = regex?.matches(in: self, options: [], range: NSRange(location: 0, length: nsString.length))
 
-        guard let lastMatch = results?.last else { return nil }
+        // Find the nearest tag before the cursor
+        guard let lastMatch = results?.last(where: { $0.range.location < nsString.length }) else { return nil }
         let tagNameRange = lastMatch.range(at: 1)
         let attributesRange = lastMatch.range(at: 2)
         let tagName = nsString.substring(with: tagNameRange)

--- a/Sources/CodeEditSourceEditor/Filters/TagFilter.swift
+++ b/Sources/CodeEditSourceEditor/Filters/TagFilter.swift
@@ -19,12 +19,10 @@ struct TagFilter: Filter {
         with whitespaceProvider: WhitespaceProviders
     ) -> FilterAction {
         guard isRelevantLanguage() else {
-            print(language)
             return .none
         }
         guard let range = Range(mutation.range, in: interface.string) else { return .none }
         let insertedText = mutation.string
-        print(insertedText)
         let fullText = interface.string
 
         // Check if the inserted text is a closing bracket '>'

--- a/Sources/CodeEditSourceEditor/Filters/TagFilter.swift
+++ b/Sources/CodeEditSourceEditor/Filters/TagFilter.swift
@@ -11,6 +11,7 @@ import TextStory
 
 struct TagFilter: Filter {
     var language: String
+    private let newlineFilter = NewlineProcessingFilter()
 
     func processMutation(
         _ mutation: TextMutation,

--- a/Sources/CodeEditSourceEditor/Filters/TagFilter.swift
+++ b/Sources/CodeEditSourceEditor/Filters/TagFilter.swift
@@ -53,7 +53,7 @@ struct TagFilter: Filter {
 private extension String {
     var lastTag: (name: String, isSelfClosing: Bool)? {
         // Regex to find the last tag
-        let regex = try? NSRegularExpression(pattern: "<([a-zA-Z]+)([^>]*)>", options: .caseInsensitive)
+        let regex = try? NSRegularExpression(pattern: "<([a-zA-Z0-9]+)([^>]*)>", options: .caseInsensitive)
         let nsString = self as NSString
         let results = regex?.matches(in: self, options: [], range: NSRange(location: 0, length: nsString.length))
 

--- a/Sources/CodeEditSourceEditor/Filters/TagFilter.swift
+++ b/Sources/CodeEditSourceEditor/Filters/TagFilter.swift
@@ -10,11 +10,17 @@ import TextFormation
 import TextStory
 
 struct TagFilter: Filter {
+    var language: String
+
     func processMutation(
         _ mutation: TextMutation,
         in interface: TextInterface,
         with whitespaceProvider: WhitespaceProviders
     ) -> FilterAction {
+        guard isRelevantLanguage() else {
+            print(language)
+            return .none
+        }
         guard let range = Range(mutation.range, in: interface.string) else { return .none }
         let insertedText = mutation.string
         print(insertedText)
@@ -39,6 +45,10 @@ struct TagFilter: Filter {
         }
 
         return .none
+    }
+    private func isRelevantLanguage() -> Bool {
+        let relevantLanguages = ["html", "javascript", "typescript", "jsx", "tsx"]
+        return relevantLanguages.contains(language)
     }
 }
 private extension String {

--- a/Sources/CodeEditSourceEditor/Filters/TagFilter.swift
+++ b/Sources/CodeEditSourceEditor/Filters/TagFilter.swift
@@ -1,0 +1,60 @@
+//
+//  TagFilter.swift
+//
+//
+//  Created by Roscoe Rubin-Rottenberg on 5/18/24.
+//
+
+import Foundation
+import TextFormation
+import TextStory
+
+struct TagFilter: Filter {
+    func processMutation(
+        _ mutation: TextMutation,
+        in interface: TextInterface,
+        with whitespaceProvider: WhitespaceProviders
+    ) -> FilterAction {
+        guard let range = Range(mutation.range, in: interface.string) else { return .none }
+        let insertedText = mutation.string
+        print(insertedText)
+        let fullText = interface.string
+
+        // Check if the inserted text is a closing bracket '>'
+        if insertedText == ">" {
+            let textBeforeCursor = "\(String(fullText[..<range.lowerBound]))\(insertedText)"
+            if let lastOpenTag = textBeforeCursor.lastTag {
+                // Check if the tag is not self-closing and there isn't already a closing tag
+                if !lastOpenTag.isSelfClosing && !textBeforeCursor.contains("</\(lastOpenTag.name)>") {
+                    let closingTag = "</\(lastOpenTag.name)>"
+                    let newRange = NSRange(location: mutation.range.location + 1, length: 0)
+                    DispatchQueue.main.async {
+                        let newMutation = TextMutation(string: closingTag, range: newRange, limit: 50)
+                        interface.applyMutation(newMutation)
+                        let cursorPosition = NSRange(location: newRange.location, length: 0)
+                        interface.selectedRange = cursorPosition
+                    }
+                }
+            }
+        }
+
+        return .none
+    }
+}
+private extension String {
+    var lastTag: (name: String, isSelfClosing: Bool)? {
+        // Regex to find the last tag
+        let regex = try? NSRegularExpression(pattern: "<([a-zA-Z]+)([^>]*)>", options: .caseInsensitive)
+        let nsString = self as NSString
+        let results = regex?.matches(in: self, options: [], range: NSRange(location: 0, length: nsString.length))
+
+        guard let lastMatch = results?.last else { return nil }
+        let tagNameRange = lastMatch.range(at: 1)
+        let attributesRange = lastMatch.range(at: 2)
+        let tagName = nsString.substring(with: tagNameRange)
+        let attributes = nsString.substring(with: attributesRange)
+        let isSelfClosing = attributes.contains("/")
+
+        return (name: tagName, isSelfClosing: isSelfClosing)
+    }
+}


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

<!--- REQUIRED: Describe what changed in detail -->
Tags in HTML, JS, TS, JSX, and TSX are now autocompleted. When you type `<div>` for example, the closing tag `</div>` will be autocompleted. If you press enter, you will be put on a new line in between the opening and closing and that new line will be indented. All tag attributes are ignored in the closing tag.

### Related Issues


<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #244

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

https://github.com/CodeEditApp/CodeEditSourceEditor/assets/118622417/cf9ffe27-7592-49d5-bee8-edacdd6ab5f4


<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
