### PR TITLE
Use System Cursor

### DIFF
--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
-        "version" : "1.1.0"
+        "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
+        "version" : "1.1.1"
       }
     },
     {

--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/ContentView.swift
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/ContentView.swift
@@ -19,6 +19,7 @@ struct ContentView: View {
     @State private var font: NSFont = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
     @AppStorage("wrapLines") private var wrapLines: Bool = true
     @State private var cursorPositions: [CursorPosition] = []
+    @AppStorage("systemCursor") private var useSystemCursor: Bool = false
 
     init(document: Binding<CodeEditSourceEditorExampleDocument>, fileURL: URL?) {
         self._document = document
@@ -32,6 +33,13 @@ struct ContentView: View {
                 LanguagePicker(language: $language)
                     .frame(maxWidth: 100)
                 Toggle("Wrap Lines", isOn: $wrapLines)
+                if #available(macOS 14, *) {
+                    Toggle("Use System Cursor", isOn: $useSystemCursor)
+                } else {
+                    Toggle("Use System Cursor", isOn: $useSystemCursor)
+                        .disabled(true)
+                        .help("macOS 14 required")
+                }
                 Spacer()
                 Text(getLabel(cursorPositions))
             }
@@ -47,7 +55,8 @@ struct ContentView: View {
                 tabWidth: 4,
                 lineHeight: 1.2,
                 wrapLines: wrapLines,
-                cursorPositions: $cursorPositions
+                cursorPositions: $cursorPositions,
+                useSystemCursor: useSystemCursor
             )
         }
         .onAppear {

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
-        "version" : "1.1.0"
+        "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
+        "version" : "1.1.1"
       }
     },
     {

--- a/Sources/CodeEditSourceEditor/CodeEditSourceEditor/CodeEditSourceEditor.swift
+++ b/Sources/CodeEditSourceEditor/CodeEditSourceEditor/CodeEditSourceEditor.swift
@@ -42,6 +42,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
     ///                    character's width between characters, etc. Defaults to `1.0`
     ///   - bracketPairHighlight: The type of highlight to use to highlight bracket pairs.
     ///                           See `BracketPairHighlight` for more information. Defaults to `nil`
+    ///   - useSystemCursor: If true, uses the system cursor on `>=macOS 14`.
     ///   - undoManager: The undo manager for the text view. Defaults to `nil`, which will create a new CEUndoManager
     ///   - coordinators: Any text coordinators for the view to use. See ``TextViewCoordinator`` for more information.
     public init(
@@ -62,6 +63,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         isSelectable: Bool = true,
         letterSpacing: Double = 1.0,
         bracketPairHighlight: BracketPairHighlight? = nil,
+        useSystemCursor: Bool = true,
         undoManager: CEUndoManager? = nil,
         coordinators: [any TextViewCoordinator] = []
     ) {
@@ -82,6 +84,11 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         self.isSelectable = isSelectable
         self.letterSpacing = letterSpacing
         self.bracketPairHighlight = bracketPairHighlight
+        if #available(macOS 14, *) {
+            self.useSystemCursor = useSystemCursor
+        } else {
+            self.useSystemCursor = false
+        }
         self.undoManager = undoManager
         self.coordinators = coordinators
     }
@@ -131,6 +138,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         isSelectable: Bool = true,
         letterSpacing: Double = 1.0,
         bracketPairHighlight: BracketPairHighlight? = nil,
+        useSystemCursor: Bool = true,
         undoManager: CEUndoManager? = nil,
         coordinators: [any TextViewCoordinator] = []
     ) {
@@ -151,6 +159,11 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         self.isSelectable = isSelectable
         self.letterSpacing = letterSpacing
         self.bracketPairHighlight = bracketPairHighlight
+        if #available(macOS 14, *) {
+            self.useSystemCursor = useSystemCursor
+        } else {
+            self.useSystemCursor = false
+        }
         self.undoManager = undoManager
         self.coordinators = coordinators
     }
@@ -172,6 +185,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
     private var isSelectable: Bool
     private var letterSpacing: Double
     private var bracketPairHighlight: BracketPairHighlight?
+    private var useSystemCursor: Bool
     private var undoManager: CEUndoManager?
     package var coordinators: [any TextViewCoordinator]
 
@@ -195,6 +209,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
             isEditable: isEditable,
             isSelectable: isSelectable,
             letterSpacing: letterSpacing,
+            useSystemCursor: useSystemCursor,
             bracketPairHighlight: bracketPairHighlight,
             undoManager: undoManager
         )
@@ -276,6 +291,10 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
             controller.letterSpacing = letterSpacing
         }
 
+        if controller.useSystemCursor != useSystemCursor {
+            controller.useSystemCursor = useSystemCursor
+        }
+
         controller.bracketPairHighlight = bracketPairHighlight
 
         controller.reloadUI()
@@ -296,7 +315,8 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         controller.indentOption == indentOption &&
         controller.tabWidth == tabWidth &&
         controller.letterSpacing == letterSpacing &&
-        controller.bracketPairHighlight == bracketPairHighlight
+        controller.bracketPairHighlight == bracketPairHighlight &&
+        controller.useSystemCursor == useSystemCursor
     }
 }
 

--- a/Sources/CodeEditSourceEditor/CodeEditSourceEditor/CodeEditSourceEditor.swift
+++ b/Sources/CodeEditSourceEditor/CodeEditSourceEditor/CodeEditSourceEditor.swift
@@ -253,6 +253,15 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
             return
         }
 
+        updateControllerParams(controller: controller)
+
+        controller.reloadUI()
+        return
+    }
+
+    /// Update the parameters of the controller.
+    /// - Parameter controller: The controller to update.
+    func updateControllerParams(controller: TextViewController) {
         if controller.font != font {
             controller.font = font
         }
@@ -296,11 +305,11 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         }
 
         controller.bracketPairHighlight = bracketPairHighlight
-
-        controller.reloadUI()
-        return
     }
 
+    /// Checks if the controller needs updating.
+    /// - Parameter controller: The controller to check.
+    /// - Returns: True, if the controller's parameters should be updated.
     func paramsAreEqual(controller: NSViewControllerType) -> Bool {
         controller.font == font &&
         controller.isEditable == isEditable &&

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -153,6 +153,18 @@ public class TextViewController: NSViewController {
         }
     }
 
+    /// If true, uses the system cursor on macOS 14 or greater.
+    public var useSystemCursor: Bool {
+        get {
+            textView.useSystemCursor
+        }
+        set {
+            if #available(macOS 14, *) {
+                textView.useSystemCursor = newValue
+            }
+        }
+    }
+
     var highlighter: Highlighter?
 
     /// The tree sitter client managed by the source editor.
@@ -198,6 +210,7 @@ public class TextViewController: NSViewController {
         isEditable: Bool,
         isSelectable: Bool,
         letterSpacing: Double,
+        useSystemCursor: Bool,
         bracketPairHighlight: BracketPairHighlight?,
         undoManager: CEUndoManager? = nil
     ) {
@@ -221,6 +234,13 @@ public class TextViewController: NSViewController {
 
         super.init(nibName: nil, bundle: nil)
 
+        let platformGuardedSystemCursor: Bool
+        if #available(macOS 14, *) {
+            platformGuardedSystemCursor = useSystemCursor
+        } else {
+            platformGuardedSystemCursor = false
+        }
+
         self.textView = TextView(
             string: string,
             font: font,
@@ -230,6 +250,7 @@ public class TextViewController: NSViewController {
             isEditable: isEditable,
             isSelectable: isSelectable,
             letterSpacing: letterSpacing,
+            useSystemCursor: platformGuardedSystemCursor,
             delegate: self
         )
     }

--- a/Tests/CodeEditSourceEditorTests/TagEditingTests.swift
+++ b/Tests/CodeEditSourceEditorTests/TagEditingTests.swift
@@ -47,6 +47,7 @@ final class TagEditingTests: XCTestCase {
             isEditable: true,
             isSelectable: true,
             letterSpacing: 1.0,
+            useSystemCursor: false,
             bracketPairHighlight: .flash
         )
         let tsClient = TreeSitterClient(executor: .init(forceSync: true))

--- a/Tests/CodeEditSourceEditorTests/TextViewControllerTests.swift
+++ b/Tests/CodeEditSourceEditorTests/TextViewControllerTests.swift
@@ -47,6 +47,7 @@ final class TextViewControllerTests: XCTestCase {
             isEditable: true,
             isSelectable: true,
             letterSpacing: 1.0,
+            useSystemCursor: false,
             bracketPairHighlight: .flash
         )
 


### PR DESCRIPTION
### Description

Adds the option to use the system cursor on macs version 14 or above.

### Related Issues

- N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
