### PR TITLE
Make TextView Public

### DIFF
--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -21,7 +21,7 @@ public class TextViewController: NSViewController {
     public static let cursorPositionUpdatedNotification: Notification.Name = .init("TextViewController.cursorPositionNotification")
 
     var scrollView: NSScrollView!
-    var textView: TextView!
+    private(set) public var textView: TextView!
     var gutterView: GutterView!
     internal var _undoManager: CEUndoManager?
     /// Internal reference to any injected layers in the text view.


### PR DESCRIPTION
Makes the textview property public. There's an existing workaround for this by grabbing the controller's views and drilling down to the text view, but this should be publicly accessible.
