### PR TITLE
Add TextViewDelegate Option to Coordinators

### DIFF
--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+Cursor.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+Cursor.swift
@@ -49,7 +49,10 @@ extension TextViewController {
 
         isPostingCursorNotification = true
         cursorPositions = positions.sorted(by: { $0.range.location < $1.range.location })
-        NotificationCenter.default.post(name: Self.cursorPositionUpdatedNotification, object: nil)
+        NotificationCenter.default.post(name: Self.cursorPositionUpdatedNotification, object: self)
+        for coordinator in self.textCoordinators.values() {
+            coordinator.textViewDidChangeSelection(controller: self, newPositions: cursorPositions)
+        }
         isPostingCursorNotification = false
     }
 }

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+TextViewDelegate.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+TextViewDelegate.swift
@@ -10,8 +10,23 @@ import CodeEditTextView
 import TextStory
 
 extension TextViewController: TextViewDelegate {
+    public func textView(_ textView: TextView, willReplaceContentsIn range: NSRange, with string: String) {
+        for coordinator in self.textCoordinators.values() {
+            if let coordinator = coordinator as? TextViewDelegate {
+                coordinator.textView(textView, willReplaceContentsIn: range, with: string)
+            }
+        }
+    }
+
     public func textView(_ textView: TextView, didReplaceContentsIn range: NSRange, with: String) {
         gutterView.needsDisplay = true
+        for coordinator in self.textCoordinators.values() {
+            if let coordinator = coordinator as? TextViewDelegate {
+                coordinator.textView(textView, didReplaceContentsIn: range, with: string)
+            } else {
+                coordinator.textViewDidChangeText(controller: self)
+            }
+        }
     }
 
     public func textView(_ textView: TextView, shouldReplaceContentsIn range: NSRange, with string: String) -> Bool {

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -166,6 +166,8 @@ public class TextViewController: NSViewController {
         }
     }
 
+    var textCoordinators: [WeakCoordinator] = []
+
     var highlighter: Highlighter?
 
     /// The tree sitter client managed by the source editor.
@@ -213,7 +215,8 @@ public class TextViewController: NSViewController {
         letterSpacing: Double,
         useSystemCursor: Bool,
         bracketPairHighlight: BracketPairHighlight?,
-        undoManager: CEUndoManager? = nil
+        undoManager: CEUndoManager? = nil,
+        coordinators: [TextViewCoordinator] = []
     ) {
         self.language = language
         self.font = font
@@ -254,6 +257,10 @@ public class TextViewController: NSViewController {
             useSystemCursor: platformGuardedSystemCursor,
             delegate: self
         )
+
+        coordinators.forEach {
+            $0.prepareCoordinator(controller: self)
+        }
     }
 
     required init?(coder: NSCoder) {
@@ -292,6 +299,10 @@ public class TextViewController: NSViewController {
         }
         highlighter = nil
         highlightProvider = nil
+        textCoordinators.values().forEach {
+            $0.destroy()
+        }
+        textCoordinators.removeAll()
         NotificationCenter.default.removeObserver(self)
         cancellables.forEach { $0.cancel() }
         if let localEvenMonitor {

--- a/Sources/CodeEditSourceEditor/Documentation.docc/TextViewCoordinators.md
+++ b/Sources/CodeEditSourceEditor/Documentation.docc/TextViewCoordinators.md
@@ -4,7 +4,11 @@ Add advanced functionality to CodeEditSourceEditor.
 
 ## Overview
 
-CodeEditSourceEditor provides an API to add more advanced functionality to the editor than SwiftUI allows. For instance, a 
+CodeEditSourceEditor provides this API as a way to push messages up from underlying components into SwiftUI land without requiring passing callbacks for each message to the ``CodeEditSourceEditor`` initializer.
+
+They're very useful for updating UI that is directly related to the state of the editor, such as the current cursor position. For an example of how this can be useful, see the ``CombineCoordinator`` class, which implements combine publishers for the messages this protocol provides.
+
+They can also be used to get more detailed text editing notifications by conforming to the `TextViewDelegate` (from CodeEditTextView) protocol. In that case they'll receive most text change notifications.
 
 ### Make a Coordinator
 
@@ -60,6 +64,21 @@ The lifecycle looks like this:
 - CodeEditSourceEditor is being closed.
   - ``TextViewCoordinator/destroy()-9nzfl`` is called.
   - CodeEditSourceEditor stops referencing the coordinator.
+
+### TextViewDelegate Conformance
+
+If a coordinator conforms to the `TextViewDelegate` protocol from the `CodeEditTextView` package, it will receive forwarded delegate messages for the editor's text view.
+
+The messages it will receive:
+```swift
+func textView(_ textView: TextView, willReplaceContentsIn range: NSRange, with string: String)
+func textView(_ textView: TextView, didReplaceContentsIn range: NSRange, with string: String)
+```
+
+It will _not_ receive the following:
+```swift
+func textView(_ textView: TextView, shouldReplaceContentsIn range: NSRange, with string: String) -> Bool
+```
 
 ### Example
 

--- a/Sources/CodeEditSourceEditor/Extensions/TextView+/TextView+TextFormation.swift
+++ b/Sources/CodeEditSourceEditor/Extensions/TextView+/TextView+TextFormation.swift
@@ -40,6 +40,8 @@ extension TextView: TextInterface {
     public func applyMutation(_ mutation: TextMutation) {
         guard !mutation.isEmpty else { return }
 
+        delegate?.textView(self, willReplaceContentsIn: mutation.range, with: mutation.string)
+
         layoutManager.beginTransaction()
         textStorage.beginEditing()
 
@@ -53,5 +55,7 @@ extension TextView: TextInterface {
 
         textStorage.endEditing()
         layoutManager.endTransaction()
+
+        delegate?.textView(self, didReplaceContentsIn: mutation.range, with: mutation.string)
     }
 }

--- a/Sources/CodeEditSourceEditor/TextViewCoordinator/TextViewCoordinator.swift
+++ b/Sources/CodeEditSourceEditor/TextViewCoordinator/TextViewCoordinator.swift
@@ -7,11 +7,17 @@
 
 import AppKit
 
-/// # TextViewCoordinator
+/// A protocol that can be used to receive extra state change messages from ``CodeEditSourceEditor``.
 ///
-/// A protocol that can be used to provide extra functionality to ``CodeEditSourceEditor/CodeEditSourceEditor`` while
-/// avoiding some of the inefficiencies of SwiftUI.
+/// These are used as a way to push messages up from underlying components into SwiftUI land without requiring passing
+/// callbacks for each message to the ``CodeEditSourceEditor`` initializer.
 ///
+/// They're very useful for updating UI that is directly related to the state of the editor, such as the current
+/// cursor position. For an example, see the ``CombineCoordinator`` class, which implements combine publishers for the
+/// messages this protocol provides.
+///
+/// Conforming objects can also be used to get more detailed text editing notifications by conforming to the
+/// `TextViewDelegate` (from CodeEditTextView) protocol. In that case they'll receive most text change notifications.
 public protocol TextViewCoordinator: AnyObject {
     /// Called when an instance of ``TextViewController`` is available. Use this method to install any delegates,
     /// perform any modifications on the text view or controller, or capture the text view for later use in your app.

--- a/Sources/CodeEditSourceEditor/Utils/CursorPosition.swift
+++ b/Sources/CodeEditSourceEditor/Utils/CursorPosition.swift
@@ -16,7 +16,7 @@ import Foundation
 /// When initialized by users, certain values may be set to `NSNotFound` or `-1` until they can be filled in by the text
 /// controller.
 /// 
-public struct CursorPosition: Sendable, Codable, Equatable {
+public struct CursorPosition: Sendable, Codable, Equatable, Hashable {
     /// Initialize a cursor position.
     ///
     /// When this initializer is used, ``CursorPosition/range`` will be initialized to `NSNotFound`.

--- a/Sources/CodeEditSourceEditor/Utils/WeakCoordinator.swift
+++ b/Sources/CodeEditSourceEditor/Utils/WeakCoordinator.swift
@@ -1,0 +1,25 @@
+//
+//  WeakCoordinator.swift
+//  CodeEditSourceEditor
+//
+//  Created by Khan Winter on 9/13/24.
+//
+
+struct WeakCoordinator {
+    weak var val: TextViewCoordinator?
+
+    init(_ val: TextViewCoordinator) {
+        self.val = val
+    }
+}
+
+extension Array where Element == WeakCoordinator {
+    mutating func clean() {
+        self.removeAll(where: { $0.val == nil })
+    }
+
+    mutating func values() -> [TextViewCoordinator] {
+        self.clean()
+        return self.compactMap({ $0.val })
+    }
+}


### PR DESCRIPTION
### Description

Main Changes:
- Adds the ability to conform `TextViewCoordinator`s to `TextViewDelegate` (from CETV), forwarding most delegate messages to each conforming coordinator. This allows coordinators to receive detailed text change information quickly and with much more detailed information than is given in notifications.
- Fixes a bug where delegate messages were not sent when modifying text in filters.

Details:
- Raises ownership of coordinators to the `TextViewController`, which weakly references all coordinators. The controller now also handles forwarding messages, which was previously handled by the SwiftUI coordinator.
- The SwiftUI coordinator is simplified due to not having to manage the coordinator messages.
- Updated documentation for coordinators, explaining why the API exists and describes the new delegation API.

### Related Issues

N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A
