### PR TITLE
[chore:] Update CodeEditTextView to 0.7.7

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,17 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "2619cb945b4d6c2fc13f22ba873ba891f552b0f3",
-        "version" : "0.7.6"
-      }
-    },
-    {
-      "identity" : "mainoffender",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattmassicotte/MainOffender",
-      "state" : {
-        "revision" : "343cc3797618c29b48b037b4e2beea0664e75315",
-        "version" : "0.1.0"
+        "revision" : "509d7b2e86460e8ec15b0dd5410cbc8e8c05940f",
+        "version" : "0.7.7"
       }
     },
     {
@@ -50,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
       "state" : {
-        "revision" : "f69b412a765396d44dc9f4788a5b79919c1ca9e3",
-        "version" : "0.2.2"
+        "revision" : "bea71d23db993c58934ee704f798a66d7b8cb626",
+        "version" : "0.57.0"
       }
     },
     {
@@ -68,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/TextFormation",
       "state" : {
-        "revision" : "f6faed6abd768ae95b70d10113d4008a7cac57a7",
-        "version" : "0.8.2"
+        "revision" : "b1ce9a14bd86042bba4de62236028dc4ce9db6a1",
+        "version" : "0.9.0"
       }
     },
     {
@@ -77,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/TextStory",
       "state" : {
-        "revision" : "8883fa739aa213e70e6cb109bfbf0a0b551e4cb5",
-        "version" : "0.8.0"
+        "revision" : "8dc9148b46fcf93b08ea9d4ef9bdb5e4f700e008",
+        "version" : "0.9.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         // A fast, efficient, text view for code.
         .package(
             url: "https://github.com/CodeEditApp/CodeEditTextView.git",
-            from: "0.7.6"
+            from: "0.7.7"
         ),
         // tree-sitter languages
         .package(

--- a/Tests/CodeEditSourceEditorTests/TagEditingTests.swift
+++ b/Tests/CodeEditSourceEditorTests/TagEditingTests.swift
@@ -20,6 +20,7 @@ final class TagEditingTests: XCTestCase {
         window = NSWindow()
         window.contentViewController = controller
         controller.loadView()
+        window.setFrame(NSRect(x: 0, y: 0, width: 1000, height: 1000), display: false)
     }
 
     func test_tagClose() {


### PR DESCRIPTION
Bumps CodeEditTextView to the latest version. [Release notes](https://github.com/CodeEditApp/CodeEditTextView/releases/tag/0.7.7).