### PR TITLE
[chore:] Bump CodeEditLanguages to 0.1.20

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditLanguages.git",
       "state" : {
-        "revision" : "5b27f139269e1ea49ceae5e56dca44a3ccad50a1",
-        "version" : "0.1.19"
+        "revision" : "331d5dbc5fc8513be5848fce8a2a312908f36a11",
+        "version" : "0.1.20"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/SwiftTreeSitter.git",
       "state" : {
-        "revision" : "2599e95310b3159641469d8a21baf2d3d200e61f",
-        "version" : "0.8.0"
+        "revision" : "36aa61d1b531f744f35229f010efba9c6d6cbbdd",
+        "version" : "0.9.0"
       }
     },
     {
@@ -70,6 +70,15 @@
       "state" : {
         "revision" : "8dc9148b46fcf93b08ea9d4ef9bdb5e4f700e008",
         "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "tree-sitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter",
+      "state" : {
+        "revision" : "d97db6d63507eb62c536bcb2c4ac7d70c8ec665e",
+        "version" : "0.23.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         // tree-sitter languages
         .package(
             url: "https://github.com/CodeEditApp/CodeEditLanguages.git",
-            exact: "0.1.19"
+            exact: "0.1.20"
         ),
         // SwiftLint
         .package(

--- a/Sources/CodeEditSourceEditor/TreeSitter/LanguageLayer.swift
+++ b/Sources/CodeEditSourceEditor/TreeSitter/LanguageLayer.swift
@@ -8,7 +8,7 @@
 import Foundation
 import CodeEditLanguages
 import SwiftTreeSitter
-import tree_sitter
+import TreeSitter
 
 extension Parser {
     func reset() {


### PR DESCRIPTION
Bumps the CodeEditLanguages package to 0.1.20. [Release notes](https://github.com/CodeEditApp/CodeEditLanguages/releases/tag/0.1.20).