### PR TITLE
Invalidate Correct Edited Range

### DIFF
--- a/Sources/CodeEditSourceEditor/Highlighting/HighlighProviding/HighlightProviderState.swift
+++ b/Sources/CodeEditSourceEditor/Highlighting/HighlighProviding/HighlightProviderState.swift
@@ -139,8 +139,9 @@ extension HighlightProviderState {
         highlightProvider?.applyEdit(textView: textView, range: range, delta: delta) { [weak self] result in
             switch result {
             case .success(let invalidSet):
+                let modifiedRange = NSRange(location: range.location, length: range.length + delta)
                 // Make sure we add in the edited range too
-                self?.invalidate(invalidSet.union(IndexSet(integersIn: range)))
+                self?.invalidate(invalidSet.union(IndexSet(integersIn: modifiedRange)))
             case .failure(let error):
                 if case HighlightProvidingError.operationCancelled = error {
                     self?.invalidate(IndexSet(integersIn: range))

--- a/Tests/CodeEditSourceEditorTests/Highlighting/HighlightProviderStateTest.swift
+++ b/Tests/CodeEditSourceEditorTests/Highlighting/HighlightProviderStateTest.swift
@@ -116,12 +116,13 @@ final class HighlightProviderStateTest: XCTestCase {
             language: .swift
         )
 
+        // These reflect values like `NSTextStorage` outputs, and differ from ranges used in other tests.
         let mockEdits: [(NSRange, Int)] = [
-            (NSRange(location: 0, length: 10), 10), // Inserted 10
-            (NSRange(location: 5, length: 0), -2), // Deleted 2 at 5
-            (NSRange(location: 0, length: 2), 3), // Replaced 0-2 with 3
+            (NSRange(location: 0, length: 0), 10), // Inserted 10
+            (NSRange(location: 3, length: 2), -2), // Deleted 2 at 5
+            (NSRange(location: 0, length: 2), 1),  // Replaced 0-2 with 3
             (NSRange(location: 9, length: 1), 1),
-            (NSRange(location: 0, length: 0), -10)
+            (NSRange(location: 0, length: 10), -10)
         ]
 
         for edit in mockEdits {


### PR DESCRIPTION
### Description

In the highlight state, invalidates the correct range when performing an edit.

Sometimes tree-sitter doesn't invalidate the ranges that were edited, so we need to add that edited range in. This ensures that a non-empty range is always invalidated.

### Related Issues

- Related pr: #273 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/user-attachments/assets/9e4d9b35-1e2d-44b8-9c2e-ffbfde69c8e4

Previously:

https://github.com/user-attachments/assets/4b572c31-0320-4f90-ac52-6f911713bc75


