### PR TITLE
Fix TreeSitterClient Not Being Set

### DIFF
--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -254,6 +254,11 @@ public class TextViewController: NSViewController {
             platformGuardedSystemCursor = false
         }
 
+        if let idx = highlightProviders.firstIndex(where: { $0 is TreeSitterClient }),
+           let client = highlightProviders[idx] as? TreeSitterClient {
+            self.treeSitterClient = client
+        }
+
         self.textView = TextView(
             string: string,
             font: font,

--- a/Tests/CodeEditSourceEditorTests/TextViewControllerTests.swift
+++ b/Tests/CodeEditSourceEditorTests/TextViewControllerTests.swift
@@ -418,5 +418,14 @@ final class TextViewControllerTests: XCTestCase {
         XCTAssertEqual(controller.cursorPositions[1].line, 3)
         XCTAssertEqual(controller.cursorPositions[1].column, 1)
     }
+
+    // MARK: - TreeSitterClient
+
+    func test_treeSitterSetUp() {
+        // Set up with a user-initiated `TreeSitterClient` should still use that client for things like tag
+        // completion.
+        let controller = Mock.textViewController(theme: Mock.theme())
+        XCTAssertNotNil(controller.treeSitterClient)
+    }
 }
 // swiftlint:enable all


### PR DESCRIPTION
### Description

Due to the new default initializer, the controller's `TreeSitterClient` object was not being set (meaning tag completion wasn't working). Added a test to make sure this doesn't happen in the future.

### Related Issues

N/A

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A