### PR TITLE
Fix End Of Doc Crash

### DIFF
--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample.xcodeproj/xcshareddata/xcschemes/CodeEditSourceEditorExample.xcscheme
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample.xcodeproj/xcshareddata/xcschemes/CodeEditSourceEditorExample.xcscheme
@@ -29,6 +29,18 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CodeEditSourceEditorTests"
+               BuildableName = "CodeEditSourceEditorTests"
+               BlueprintName = "CodeEditSourceEditorTests"
+               ReferencedContainer = "container:../..">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Sources/CodeEditSourceEditor/Highlighting/StyledRangeContainer/StyledRangeStore/StyledRangeStore+Coalesce.swift
+++ b/Sources/CodeEditSourceEditor/Highlighting/StyledRangeContainer/StyledRangeStore/StyledRangeStore+Coalesce.swift
@@ -8,15 +8,6 @@
 import _RopeModule
 
 extension StyledRangeStore {
-    /// Finds a Rope index, given a string offset.
-    /// - Parameter offset: The offset to query for.
-    /// - Returns: The index of the containing element in the rope.
-    func findIndex(at offset: Int) -> (index: Index, remaining: Int) {
-        _guts.find(at: offset, in: OffsetMetric(), preferEnd: false)
-    }
-}
-
-extension StyledRangeStore {
     /// Coalesce items before and after the given range.
     ///
     /// Compares the next run with the run at the given range. If they're the same, removes the next run and grows the
@@ -32,7 +23,7 @@ extension StyledRangeStore {
         }
 
         index = findIndex(at: range.lowerBound).index
-        if index > _guts.startIndex && _guts.count > 1 {
+        if index > _guts.startIndex && index < _guts.endIndex && _guts.count > 1 {
             index = _guts.index(before: index)
             coalesceRunAfter(index: &index)
         }

--- a/Sources/CodeEditSourceEditor/Highlighting/StyledRangeContainer/StyledRangeStore/StyledRangeStore+FindIndex.swift
+++ b/Sources/CodeEditSourceEditor/Highlighting/StyledRangeContainer/StyledRangeStore/StyledRangeStore+FindIndex.swift
@@ -1,0 +1,15 @@
+//
+//  StyledRangeStore+FindIndex.swift
+//  CodeEditSourceEditor
+//
+//  Created by Khan Winter on 1/6/25.
+//
+
+extension StyledRangeStore {
+    /// Finds a Rope index, given a string offset.
+    /// - Parameter offset: The offset to query for.
+    /// - Returns: The index of the containing element in the rope.
+    func findIndex(at offset: Int) -> (index: Index, remaining: Int) {
+        _guts.find(at: offset, in: OffsetMetric(), preferEnd: false)
+    }
+}

--- a/Tests/CodeEditSourceEditorTests/Highlighting/HighlighterTests.swift
+++ b/Tests/CodeEditSourceEditorTests/Highlighting/HighlighterTests.swift
@@ -38,12 +38,30 @@ final class HighlighterTests: XCTestCase {
         func attributesFor(_ capture: CaptureName?) -> [NSAttributedString.Key: Any] { [:] }
     }
 
+    class SentryStorageDelegate: NSObject, NSTextStorageDelegate {
+        var editedIndices: IndexSet = IndexSet()
+
+        func textStorage(
+            _ textStorage: NSTextStorage,
+            didProcessEditing editedMask: NSTextStorageEditActions,
+            range editedRange: NSRange,
+            changeInLength delta: Int) {
+                editedIndices.insert(integersIn: editedRange)
+            }
+    }
+
+    var attributeProvider: MockAttributeProvider!
+    var textView: TextView!
+
+    override func setUp() {
+        attributeProvider = MockAttributeProvider()
+        textView = Mock.textView()
+        textView.frame = NSRect(x: 0, y: 0, width: 1000, height: 1000)
+    }
+
     @MainActor
     func test_canceledHighlightsAreInvalidated() {
         let highlightProvider = MockHighlightProvider()
-        let attributeProvider = MockAttributeProvider()
-        let textView = Mock.textView()
-        textView.frame = NSRect(x: 0, y: 0, width: 1000, height: 1000)
         textView.setText("Hello World!")
         let highlighter = Mock.highlighter(
             textView: textView,
@@ -62,23 +80,8 @@ final class HighlighterTests: XCTestCase {
 
     @MainActor
     func test_highlightsDoNotInvalidateEntireTextView() {
-        class SentryStorageDelegate: NSObject, NSTextStorageDelegate {
-            var editedIndices: IndexSet = IndexSet()
-
-            func textStorage(
-                _ textStorage: NSTextStorage,
-                didProcessEditing editedMask: NSTextStorageEditActions,
-                range editedRange: NSRange,
-                changeInLength delta: Int) {
-                editedIndices.insert(integersIn: editedRange)
-            }
-        }
-
         let highlightProvider = TreeSitterClient()
         highlightProvider.forceSyncOperation = true
-        let attributeProvider = MockAttributeProvider()
-        let textView = Mock.textView()
-        textView.frame = NSRect(x: 0, y: 0, width: 1000, height: 1000)
         textView.setText("func helloWorld() {\n\tprint(\"Hello World!\")\n}")
 
         let highlighter = Mock.highlighter(
@@ -96,5 +99,50 @@ final class HighlighterTests: XCTestCase {
         highlighter.invalidate(invalidSet) // Invalidate first line
 
         XCTAssertEqual(sentryStorage.editedIndices, invalidSet) // Should only cause highlights on the first line
+    }
+
+    // This test isn't testing much highlighter functionality. However, we've seen crashes and other errors after normal
+    // editing that were caused by the highlighter and would only have been caught by an integration test like this.
+    @MainActor
+    func test_editFile() {
+        let highlightProvider = TreeSitterClient()
+        highlightProvider.forceSyncOperation = true
+        textView.setText("func helloWorld() {\n\tprint(\"Hello World!\")\n}") // 44 chars
+
+        let highlighter = Mock.highlighter(
+            textView: textView,
+            highlightProvider: highlightProvider,
+            attributeProvider: attributeProvider
+        )
+        textView.addStorageDelegate(highlighter)
+        highlighter.setLanguage(language: .swift)
+        highlighter.invalidate()
+
+        // Delete Characters
+        textView.replaceCharacters(in: [NSRange(location: 43, length: 1)], with: "")
+        textView.replaceCharacters(in: [NSRange(location: 0, length: 4)], with: "")
+        textView.replaceCharacters(in: [NSRange(location: 6, length: 5)], with: "")
+        textView.replaceCharacters(in: [NSRange(location: 25, length: 5)], with: "")
+
+        XCTAssertEqual(textView.string, " hello() {\n\tprint(\"Hello !\")\n")
+
+        // Insert Characters
+        textView.replaceCharacters(in: [NSRange(location: 29, length: 0)], with: "}")
+        textView.replaceCharacters(
+            in: [NSRange(location: 25, length: 0), NSRange(location: 6, length: 0)],
+            with: "World"
+        )
+        // emulate typing with a cursor
+        textView.selectionManager.setSelectedRange(NSRange(location: 0, length: 0))
+        textView.insertText("f")
+        textView.insertText("u")
+        textView.insertText("n")
+        textView.insertText("c")
+        XCTAssertEqual(textView.string, "func helloWorld() {\n\tprint(\"Hello World!\")\n}")
+
+        // Replace contents
+        textView.replaceCharacters(in: textView.documentRange, with: "")
+        textView.insertText("func helloWorld() {\n\tprint(\"Hello World!\")\n}")
+        XCTAssertEqual(textView.string, "func helloWorld() {\n\tprint(\"Hello World!\")\n}")
     }
 }

--- a/Tests/CodeEditSourceEditorTests/Highlighting/StyledRangeStoreTests.swift
+++ b/Tests/CodeEditSourceEditorTests/Highlighting/StyledRangeStoreTests.swift
@@ -36,6 +36,20 @@ final class StyledRangeStoreTests: XCTestCase {
         XCTAssertEqual(store.count, 1, "Failed to coalesce")
     }
 
+    func test_storageRemoveSingleCharacterFromEnd() {
+        let store = StyledRangeStore(documentLength: 10)
+        store.set( // Test that we can delete a character associated with a single syntax run too
+            runs: [
+                .empty(length: 8),
+                .init(length: 1, modifiers: [.abstract]),
+                .init(length: 1, modifiers: [.declaration])],
+            for: 0..<10
+        )
+        store.storageUpdated(replacedCharactersIn: 9..<10, withCount: 0)
+        XCTAssertEqual(store.length, 9, "Failed to remove correct range")
+        XCTAssertEqual(store.count, 2)
+    }
+
     func test_storageRemoveFromBeginning() {
         let store = StyledRangeStore(documentLength: 100)
         store.storageUpdated(replacedCharactersIn: 0..<15, withCount: 0)


### PR DESCRIPTION
### Description

Fixes a crash that occurred when editing the last characters in a file. This was missed by tests because it only appeared when syntax highlighting was applied.

Added a test case that catches this case in the styled range store. Added a second test in the highlighter tests that catches this and hopefully helps prevent some future bugs related to the highlighter.

Also added the package tests to the example app so tests can be run from the example project.

### Related Issues

* #284 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A
