### PR TITLE
Always Show Highlights After Applying

### DIFF
--- a/Sources/CodeEditSourceEditor/Highlighting/Highlighter.swift
+++ b/Sources/CodeEditSourceEditor/Highlighting/Highlighter.swift
@@ -201,7 +201,7 @@ extension Highlighter: NSTextStorageDelegate {
 extension Highlighter: StyledRangeContainerDelegate {
     func styleContainerDidUpdate(in range: NSRange) {
         guard let textView, let attributeProvider else { return }
-//        textView.layoutManager.beginTransaction()
+        textView.layoutManager.beginTransaction()
         textView.textStorage.beginEditing()
 
         let storage = textView.textStorage
@@ -216,8 +216,8 @@ extension Highlighter: StyledRangeContainerDelegate {
         }
 
         textView.textStorage.endEditing()
-//        textView.layoutManager.endTransaction()
-//        textView.layoutManager.invalidateLayoutForRange(range)
+        textView.layoutManager.endTransaction()
+        textView.layoutManager.invalidateLayoutForRange(range)
     }
 }
 


### PR DESCRIPTION
### Description

- Invalidates highlighted ranges in the layout manager after applying highlights. This fixes highlights not appearing after undoing/redoing edits. The code doing this was commented out in #273. It was likely missed because that was such a large PR.

### Related Issues

- N/A

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

CodeEdit 0.3.3

https://github.com/user-attachments/assets/09644b58-b5fb-40c5-bdc1-c89695d5e436

After Changes

https://github.com/user-attachments/assets/65bd6e16-5348-494d-8436-adb1b6a6f9c8

