### PR TITLE
Bump CETV, Revert Trailing Padding (#272)

### DIFF
--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditLanguages.git",
       "state" : {
-        "revision" : "5b27f139269e1ea49ceae5e56dca44a3ccad50a1",
-        "version" : "0.1.19"
+        "revision" : "331d5dbc5fc8513be5848fce8a2a312908f36a11",
+        "version" : "0.1.20"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/SwiftTreeSitter.git",
       "state" : {
-        "revision" : "2599e95310b3159641469d8a21baf2d3d200e61f",
-        "version" : "0.8.0"
+        "revision" : "36aa61d1b531f744f35229f010efba9c6d6cbbdd",
+        "version" : "0.9.0"
       }
     },
     {
@@ -61,6 +61,15 @@
       "state" : {
         "revision" : "8dc9148b46fcf93b08ea9d4ef9bdb5e4f700e008",
         "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "tree-sitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter",
+      "state" : {
+        "revision" : "d97db6d63507eb62c536bcb2c4ac7d70c8ec665e",
+        "version" : "0.23.2"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "8ceb3fdff6c7736adcc506ce5aee4eb91973d783",
-        "version" : "0.7.8"
+        "revision" : "1792167c751b6668b4743600d2cf73d2829dd18a",
+        "version" : "0.7.9"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,8 @@ let package = Package(
     dependencies: [
         // A fast, efficient, text view for code.
         .package(
-            path: "../CodeEditTextView"
-//            url: "https://github.com/CodeEditApp/CodeEditTextView.git",
-//            from: "0.7.7"
+            url: "https://github.com/CodeEditApp/CodeEditTextView.git",
+            from: "0.7.9"
         ),
         // tree-sitter languages
         .package(

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,9 @@ let package = Package(
     dependencies: [
         // A fast, efficient, text view for code.
         .package(
-            url: "https://github.com/CodeEditApp/CodeEditTextView.git",
-            from: "0.7.7"
+            path: "../CodeEditTextView"
+//            url: "https://github.com/CodeEditApp/CodeEditTextView.git",
+//            from: "0.7.7"
         ),
         // tree-sitter languages
         .package(

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+StyleViews.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+StyleViews.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import CodeEditTextView
 
 extension TextViewController {
     package func generateParagraphStyle() -> NSMutableParagraphStyle {

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -93,10 +93,7 @@ public class TextViewController: NSViewController {
         didSet {
             textView.layoutManager.wrapLines = wrapLines
             scrollView.hasHorizontalScroller = !wrapLines
-            textView.edgeInsets = HorizontalEdgeInsets(
-                left: textView.edgeInsets.left,
-                right: textViewTrailingInset // Refresh this value, see docs
-            )
+            textView.textInsets = textViewInsets
         }
     }
 
@@ -200,7 +197,16 @@ public class TextViewController: NSViewController {
 
     /// The trailing inset for the editor. Grows when line wrapping is disabled.
     package var textViewTrailingInset: CGFloat {
-        wrapLines ? 1 : 48
+        // See https://github.com/CodeEditApp/CodeEditTextView/issues/66
+        // wrapLines ? 1 : 48
+        0
+    }
+
+    package var textViewInsets: HorizontalEdgeInsets {
+        HorizontalEdgeInsets(
+            left: gutterView.gutterWidth,
+            right: textViewTrailingInset
+        )
     }
 
     // MARK: Init
@@ -329,6 +335,6 @@ public class TextViewController: NSViewController {
 extension TextViewController: GutterViewDelegate {
     public func gutterViewWidthDidUpdate(newWidth: CGFloat) {
         gutterView?.frame.size.width = newWidth
-        textView?.edgeInsets = HorizontalEdgeInsets(left: newWidth, right: textViewTrailingInset)
+        textView?.textInsets = textViewInsets
     }
 }


### PR DESCRIPTION
### Description

> Draft until linked CETV patch is merged and released.

Bumps CETV, reverts the trailing padding change in #272 for a future change (tracked in https://github.com/CodeEditApp/CodeEditTextView/issues/66).

Should be ready for a release after this!

### Related Issues

* https://github.com/CodeEditApp/CodeEditTextView/pull/67

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A