### PR TITLE
Fix Delegate Typo

### DIFF
--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+TextViewDelegate.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+TextViewDelegate.swift
@@ -18,7 +18,7 @@ extension TextViewController: TextViewDelegate {
         }
     }
 
-    public func textView(_ textView: TextView, didReplaceContentsIn range: NSRange, with: String) {
+    public func textView(_ textView: TextView, didReplaceContentsIn range: NSRange, with string: String) {
         gutterView.needsDisplay = true
         for coordinator in self.textCoordinators.values() {
             if let coordinator = coordinator as? TextViewDelegate {


### PR DESCRIPTION
### Description

Fixes a typo in the TextViewController's text view delegate conformance. This wasn't caught by the compiler because the methods are optional.

### Related Issues

N/A

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A