### PR TITLE
Move Overscroll To TextView

### DIFF
--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+IndentLines.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+IndentLines.swift
@@ -1,12 +1,12 @@
 //
 //  TextViewController+IndentLines.swift
-//
+//  CodeEditTextView
 //
 //  Created by Ludwig, Tom on 11.09.24.
 //
 
-import CodeEditTextView
 import AppKit
+import CodeEditTextView
 
 extension TextViewController {
     /// Handles indentation and unindentation
@@ -23,7 +23,7 @@ extension TextViewController {
         guard !cursorPositions.isEmpty else { return }
 
         textView.undoManager?.beginUndoGrouping()
-for cursorPosition in self.cursorPositions.reversed() {
+        for cursorPosition in self.cursorPositions.reversed() {
             // get lineindex, i.e line-numbers+1
             guard let lineIndexes = getHighlightedLines(for: cursorPosition.range) else { continue }
 

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+StyleViews.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+StyleViews.swift
@@ -67,6 +67,6 @@ extension TextViewController {
         } else {
             scrollView.automaticallyAdjustsContentInsets = true
         }
-        scrollView.contentInsets.bottom = (contentInsets?.bottom ?? 0) + bottomContentInsets
+        scrollView.contentInsets.bottom = contentInsets?.bottom ?? 0
     }
 }

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -104,7 +104,11 @@ public class TextViewController: NSViewController {
     ///
     /// Measured in a percentage of the view's total height, meaning a `0.3` value will result in overscroll
     /// of 1/3 of the view.
-    public var editorOverscroll: CGFloat
+    public var editorOverscroll: CGFloat {
+        didSet {
+            textView.overscrollAmount = editorOverscroll
+        }
+    }
 
     /// Whether the code editor should use the theme background color or be transparent
     public var useThemeBackground: Bool
@@ -182,18 +186,6 @@ public class TextViewController: NSViewController {
     internal var textFilters: [TextFormation.Filter] = []
 
     internal var cancellables = Set<AnyCancellable>()
-
-    /// ScrollView's bottom inset using as editor overscroll
-    package var bottomContentInsets: CGFloat {
-        let height = view.frame.height
-        var inset = editorOverscroll * height
-
-        if height - inset < font.lineHeight * lineHeightMultiple {
-            inset = height - font.lineHeight * lineHeightMultiple
-        }
-
-        return max(inset, .zero)
-    }
 
     /// The trailing inset for the editor. Grows when line wrapping is disabled.
     package var textViewTrailingInset: CGFloat {

--- a/Tests/CodeEditSourceEditorTests/TextViewControllerTests.swift
+++ b/Tests/CodeEditSourceEditorTests/TextViewControllerTests.swift
@@ -63,6 +63,24 @@ final class TextViewControllerTests: XCTestCase {
         XCTAssertEqual(color4, NSColor.textColor)
     }
 
+    // MARK: Overscroll
+
+    func test_editorOverScroll() throws {
+        controller.editorOverscroll = 0
+
+        // editorOverscroll: 0
+        XCTAssertEqual(controller.textView.overscrollAmount, 0)
+
+        controller.editorOverscroll = 0.5
+
+        // editorOverscroll: 0.5
+        XCTAssertEqual(controller.textView.overscrollAmount, 0.5)
+
+        controller.editorOverscroll = 1.0
+
+        XCTAssertEqual(controller.textView.overscrollAmount, 1.0)
+    }
+
     // MARK: Insets
 
     func test_editorInsets() throws {
@@ -106,10 +124,10 @@ final class TextViewControllerTests: XCTestCase {
         // contentInsets: 16
         // editorOverscroll: 0.5
         controller.contentInsets = NSEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
-        controller.editorOverscroll = 0.5
+        controller.editorOverscroll = 0.5 // Should be ignored
         controller.reloadUI()
 
-        try assertInsetsEqual(scrollView.contentInsets, NSEdgeInsets(top: 16, left: 16, bottom: 16 + 50, right: 16))
+        try assertInsetsEqual(scrollView.contentInsets, NSEdgeInsets(top: 16, left: 16, bottom: 16, right: 16))
         XCTAssertEqual(controller.gutterView.frame.origin.y, -16)
     }
 

--- a/Tests/CodeEditSourceEditorTests/TextViewControllerTests.swift
+++ b/Tests/CodeEditSourceEditorTests/TextViewControllerTests.swift
@@ -63,35 +63,6 @@ final class TextViewControllerTests: XCTestCase {
         XCTAssertEqual(color4, NSColor.textColor)
     }
 
-    // MARK: Overscroll
-
-    func test_editorOverScroll() throws {
-        let scrollView = try XCTUnwrap(controller.view as? NSScrollView)
-        scrollView.frame = .init(x: .zero,
-                                 y: .zero,
-                                 width: 100,
-                                 height: 100)
-
-        controller.editorOverscroll = 0
-        controller.contentInsets = nil
-        controller.reloadUI()
-
-        // editorOverscroll: 0
-        XCTAssertEqual(scrollView.contentView.contentInsets.bottom, 0)
-
-        controller.editorOverscroll = 0.5
-        controller.reloadUI()
-
-        // editorOverscroll: 0.5
-        XCTAssertEqual(scrollView.contentView.contentInsets.bottom, 50.0)
-
-        controller.editorOverscroll = 1.0
-        controller.reloadUI()
-
-        // editorOverscroll: 1.0
-        XCTAssertEqual(scrollView.contentView.contentInsets.bottom, 87.0)
-    }
-
     // MARK: Insets
 
     func test_editorInsets() throws {


### PR DESCRIPTION
### Description

The current overscroll behavior that was being handled in the SourceEditor relied on a content inset, which was a little buggy and did not allow the user to click in the over scrolled area to set the cursor. This behavior was moved to TextView instead in order to fix this.

### Related Issues


### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
