### PR TITLE
Fix StyledRangeStore Crash

### DIFF
--- a/Sources/CodeEditSourceEditor/Highlighting/StyledRangeContainer/StyledRangeStore/StyledRangeStore.swift
+++ b/Sources/CodeEditSourceEditor/Highlighting/StyledRangeContainer/StyledRangeStore/StyledRangeStore.swift
@@ -73,6 +73,13 @@ final class StyledRangeStore {
     ///   - runs: The runs to insert.
     ///   - range: The range to replace.
     func set(runs: [Run], for range: Range<Int>) {
+        let gutsRange = 0..<_guts.count(in: OffsetMetric())
+        if range.clamped(to: gutsRange) != range {
+            let upperBound = range.clamped(to: gutsRange).upperBound
+            let missingCharacters = range.upperBound - upperBound
+            storageUpdated(replacedCharactersIn: upperBound..<upperBound, withCount: missingCharacters)
+        }
+
         _guts.replaceSubrange(
             range,
             in: OffsetMetric(),


### PR DESCRIPTION
### Description

Fixes a potential crash with the styled range store. This is caused by a race condition where the store hasn't been notified of a content length change, but has been given new data to put in the (valid) range. This only happens when content is appended to the end of a document and comes into view at the same time. This is fixed by simply appending the missing range when updating the style storage object.

### Related Issues

N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A