### PR TITLE
[chore:] Update CodeEditTextView to 0.9.1

### DIFF
--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "02202a8d925dc902f18626e953b3447e320253d1",
-        "version" : "0.8.1"
+        "revision" : "66e10658b5a0199479b1534f9bef531df34d0a91",
+        "version" : "0.9.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "47faec9fb571c9c695897e69f0a4f08512ae682e",
-        "version" : "0.8.2"
+        "revision" : "337b05f22f381f020ab188d3765767e19556d78c",
+        "version" : "0.9.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         // A fast, efficient, text view for code.
         .package(
             url: "https://github.com/CodeEditApp/CodeEditTextView.git",
-            from: "0.8.2"
+            from: "0.9.1"
         ),
         // tree-sitter languages
         .package(

--- a/Sources/CodeEditSourceEditor/Extensions/TextView+/TextView+TextFormation.swift
+++ b/Sources/CodeEditSourceEditor/Extensions/TextView+/TextView+TextFormation.swift
@@ -39,23 +39,11 @@ extension TextView: TextInterface {
     /// - Parameter mutation: The mutation to apply.
     public func applyMutation(_ mutation: TextMutation) {
         guard !mutation.isEmpty else { return }
-
-        delegate?.textView(self, willReplaceContentsIn: mutation.range, with: mutation.string)
-
-        layoutManager.beginTransaction()
-        textStorage.beginEditing()
-
-        layoutManager.willReplaceCharactersInRange(range: mutation.range, with: mutation.string)
         _undoManager?.registerMutation(mutation)
         textStorage.replaceCharacters(in: mutation.range, with: mutation.string)
         selectionManager.didReplaceCharacters(
             in: mutation.range,
             replacementLength: (mutation.string as NSString).length
         )
-
-        textStorage.endEditing()
-        layoutManager.endTransaction()
-
-        delegate?.textView(self, didReplaceContentsIn: mutation.range, with: mutation.string)
     }
 }

--- a/Sources/CodeEditSourceEditor/Highlighting/Highlighter.swift
+++ b/Sources/CodeEditSourceEditor/Highlighting/Highlighter.swift
@@ -266,7 +266,6 @@ extension Highlighter: NSTextStorageDelegate {
 extension Highlighter: StyledRangeContainerDelegate {
     func styleContainerDidUpdate(in range: NSRange) {
         guard let textView, let attributeProvider else { return }
-        textView.layoutManager.beginTransaction()
         textView.textStorage.beginEditing()
 
         let storage = textView.textStorage
@@ -281,8 +280,6 @@ extension Highlighter: StyledRangeContainerDelegate {
         }
 
         textView.textStorage.endEditing()
-        textView.layoutManager.endTransaction()
-        textView.layoutManager.invalidateLayoutForRange(range)
     }
 }
 


### PR DESCRIPTION
Updates CodeEditTextView to `0.9.1` from `0.8.3`. Includes changes from [`0.9.0`](https://github.com/CodeEditApp/CodeEditTextView/releases/tag/0.9.0) and [`0.9.1`](https://github.com/CodeEditApp/CodeEditTextView/releases/tag/0.9.1)