### PR TITLE
Fix Gutter Ambiguous Position

### DIFF
--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
@@ -122,7 +122,6 @@ extension TextViewController {
             object: textView,
             queue: .main
         ) { [weak self] _ in
-            guard let scrollView = self?.scrollView else { return }
             self?.gutterView.frame.size.height = max(
                 (self?.textView.frame.height ?? 0) + 10,
                 (self?.scrollView.documentVisibleRect.height ?? 0.0) + (self?.scrollView.contentInsets.vertical ?? 0.0)

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
@@ -23,10 +23,7 @@ extension TextViewController {
             delegate: self
         )
         gutterView.updateWidthIfNeeded()
-        scrollView.addFloatingSubview(
-            gutterView,
-            for: .horizontal
-        )
+        scrollView.addFloatingSubview(gutterView, for: .horizontal)
 
         minimapView = MinimapView(textView: textView, theme: theme)
         scrollView.addFloatingSubview(minimapView, for: .vertical)
@@ -90,6 +87,8 @@ extension TextViewController {
             minimapXConstraint,
             maxWidthConstraint,
             relativeWidthConstraint,
+
+            gutterView.topAnchor.constraint(equalTo: textView.topAnchor)
         ])
     }
 
@@ -123,7 +122,11 @@ extension TextViewController {
             object: textView,
             queue: .main
         ) { [weak self] _ in
-            self?.gutterView.frame.size.height = (self?.textView.frame.height ?? 0) + 10
+            guard let scrollView = self?.scrollView else { return }
+            self?.gutterView.frame.size.height = max(
+                (self?.textView.frame.height ?? 0) + 10,
+                (self?.scrollView.documentVisibleRect.height ?? 0.0) + (self?.scrollView.contentInsets.vertical ?? 0.0)
+            )
             self?.gutterView.needsDisplay = true
         }
 


### PR DESCRIPTION
### Description

Because the gutter view was being placed using specific Y positions, and is now mixed with layout constraints, the layout constraint system sometimes messed up the positioning because the calculated y positions were 'ambiguous'. This fixes the gutter positioning problem by constraining the top of the gutter view to the top of the text view, and keeping the other position/height updating methods.

### Related Issues

* N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Before, would only appear on small files (1-3 lines):

![Screenshot 2025-04-22 at 10 40 16 AM](https://github.com/user-attachments/assets/fbade1e5-200d-4e46-8b6a-bcd6145ec7b7)

After:

![Screenshot 2025-04-22 at 10 36 08 AM](https://github.com/user-attachments/assets/46963668-af4c-42f8-a83f-01c7404589bb)
