### PR TITLE
Added Reformatting Guide

### DIFF
--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/ContentView.swift
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/ContentView.swift
@@ -28,16 +28,8 @@ struct ContentView: View {
     @State private var treeSitterClient = TreeSitterClient()
     @AppStorage("showMinimap") private var showMinimap: Bool = true
     @State private var indentOption: IndentOption = .spaces(count: 4)
-    @AppStorage("reformatAtColumn") private var reformatAtColumn: Int = 80 {
-        didSet {
-            print("reformatAtColumn changed to: \(reformatAtColumn)")
-        }
-    }
-    @AppStorage("showReformattingGuide") private var showReformattingGuide: Bool = false {
-        didSet {
-            print("showReformattingGuide changed to: \(showReformattingGuide)")
-        }
-    }
+    @AppStorage("reformatAtColumn") private var reformatAtColumn: Int = 80
+    @AppStorage("showReformattingGuide") private var showReformattingGuide: Bool = false
 
     init(document: Binding<CodeEditSourceEditorExampleDocument>, fileURL: URL?) {
         self._document = document
@@ -100,12 +92,6 @@ struct ContentView: View {
                 } else {
                     theme = .light
                 }
-            }
-            .onChange(of: reformatAtColumn) { _, newValue in
-                print("ContentView: reformatAtColumn changed to \(newValue)")
-            }
-            .onChange(of: showReformattingGuide) { _, newValue in
-                print("ContentView: showReformattingGuide changed to \(newValue)")
             }
         }
     }

--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/ContentView.swift
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/ContentView.swift
@@ -28,6 +28,16 @@ struct ContentView: View {
     @State private var treeSitterClient = TreeSitterClient()
     @AppStorage("showMinimap") private var showMinimap: Bool = true
     @State private var indentOption: IndentOption = .spaces(count: 4)
+    @AppStorage("reformatAtColumn") private var reformatAtColumn: Int = 80 {
+        didSet {
+            print("reformatAtColumn changed to: \(reformatAtColumn)")
+        }
+    }
+    @AppStorage("showReformattingGuide") private var showReformattingGuide: Bool = false {
+        didSet {
+            print("showReformattingGuide changed to: \(showReformattingGuide)")
+        }
+    }
 
     init(document: Binding<CodeEditSourceEditorExampleDocument>, fileURL: URL?) {
         self._document = document
@@ -52,7 +62,9 @@ struct ContentView: View {
                 contentInsets: NSEdgeInsets(top: proxy.safeAreaInsets.top, left: 0, bottom: 28.0, right: 0),
                 additionalTextInsets: NSEdgeInsets(top: 1, left: 0, bottom: 1, right: 0),
                 useSystemCursor: useSystemCursor,
-                showMinimap: showMinimap
+                showMinimap: showMinimap,
+                reformatAtColumn: reformatAtColumn,
+                showReformattingGuide: showReformattingGuide
             )
             .overlay(alignment: .bottom) {
                 StatusBar(
@@ -65,7 +77,9 @@ struct ContentView: View {
                     language: $language,
                     theme: $theme,
                     showMinimap: $showMinimap,
-                    indentOption: $indentOption
+                    indentOption: $indentOption,
+                    reformatAtColumn: $reformatAtColumn,
+                    showReformattingGuide: $showReformattingGuide
                 )
             }
             .ignoresSafeArea()
@@ -86,6 +100,12 @@ struct ContentView: View {
                 } else {
                     theme = .light
                 }
+            }
+            .onChange(of: reformatAtColumn) { _, newValue in
+                print("ContentView: reformatAtColumn changed to \(newValue)")
+            }
+            .onChange(of: showReformattingGuide) { _, newValue in
+                print("ContentView: showReformattingGuide changed to \(newValue)")
             }
         }
     }

--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/StatusBar.swift
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/StatusBar.swift
@@ -24,12 +24,25 @@ struct StatusBar: View {
     @Binding var theme: EditorTheme
     @Binding var showMinimap: Bool
     @Binding var indentOption: IndentOption
+    @Binding var reformatAtColumn: Int
+    @Binding var showReformattingGuide: Bool
 
     var body: some View {
         HStack {
             Menu {
+                IndentPicker(indentOption: $indentOption, enabled: document.text.isEmpty)
+                    .buttonStyle(.borderless)
                 Toggle("Wrap Lines", isOn: $wrapLines)
                 Toggle("Show Minimap", isOn: $showMinimap)
+                Toggle("Show Reformatting Guide", isOn: $showReformattingGuide)
+                Picker("Reformat column at column", selection: $reformatAtColumn) {
+                    ForEach([40, 60, 80, 100, 120, 140, 160, 180, 200], id: \.self) { column in
+                        Text("\(column)").tag(column)
+                    }
+                }
+                .onChange(of: reformatAtColumn) { _, newValue in
+                    reformatAtColumn = max(1, min(200, newValue))
+                }
                 if #available(macOS 14, *) {
                     Toggle("Use System Cursor", isOn: $useSystemCursor)
                 } else {
@@ -64,8 +77,6 @@ struct StatusBar: View {
             Divider()
                 .frame(height: 12)
             LanguagePicker(language: $language)
-                .buttonStyle(.borderless)
-            IndentPicker(indentOption: $indentOption, enabled: document.text.isEmpty)
                 .buttonStyle(.borderless)
         }
         .font(.subheadline)

--- a/Sources/CodeEditSourceEditor/CodeEditSourceEditor/CodeEditSourceEditor.swift
+++ b/Sources/CodeEditSourceEditor/CodeEditSourceEditor/CodeEditSourceEditor.swift
@@ -50,6 +50,9 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
     ///   - useSystemCursor: If true, uses the system cursor on `>=macOS 14`.
     ///   - undoManager: The undo manager for the text view. Defaults to `nil`, which will create a new CEUndoManager
     ///   - coordinators: Any text coordinators for the view to use. See ``TextViewCoordinator`` for more information.
+    ///   - showMinimap: Whether to show the minimap
+    ///   - reformatAtColumn: The column to reformat at
+    ///   - showReformattingGuide: Whether to show the reformatting guide
     public init(
         _ text: Binding<String>,
         language: CodeLanguage,
@@ -72,7 +75,9 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         useSystemCursor: Bool = true,
         undoManager: CEUndoManager? = nil,
         coordinators: [any TextViewCoordinator] = [],
-        showMinimap: Bool
+        showMinimap: Bool,
+        reformatAtColumn: Int,
+        showReformattingGuide: Bool
     ) {
         self.text = .binding(text)
         self.language = language
@@ -100,6 +105,8 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         self.undoManager = undoManager
         self.coordinators = coordinators
         self.showMinimap = showMinimap
+        self.reformatAtColumn = reformatAtColumn
+        self.showReformattingGuide = showReformattingGuide
     }
 
     /// Initializes a Text Editor
@@ -129,6 +136,9 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
     ///                           See `BracketPairEmphasis` for more information. Defaults to `nil`
     ///   - undoManager: The undo manager for the text view. Defaults to `nil`, which will create a new CEUndoManager
     ///   - coordinators: Any text coordinators for the view to use. See ``TextViewCoordinator`` for more information.
+    ///   - showMinimap: Whether to show the minimap
+    ///   - reformatAtColumn: The column to reformat at
+    ///   - showReformattingGuide: Whether to show the reformatting guide
     public init(
         _ text: NSTextStorage,
         language: CodeLanguage,
@@ -151,7 +161,9 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         useSystemCursor: Bool = true,
         undoManager: CEUndoManager? = nil,
         coordinators: [any TextViewCoordinator] = [],
-        showMinimap: Bool
+        showMinimap: Bool,
+        reformatAtColumn: Int,
+        showReformattingGuide: Bool
     ) {
         self.text = .storage(text)
         self.language = language
@@ -179,6 +191,8 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         self.undoManager = undoManager
         self.coordinators = coordinators
         self.showMinimap = showMinimap
+        self.reformatAtColumn = reformatAtColumn
+        self.showReformattingGuide = showReformattingGuide
     }
 
     package var text: TextAPI
@@ -203,6 +217,8 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
     private var undoManager: CEUndoManager?
     package var coordinators: [any TextViewCoordinator]
     package var showMinimap: Bool
+    private var reformatAtColumn: Int
+    private var showReformattingGuide: Bool
 
     public typealias NSViewControllerType = TextViewController
 
@@ -229,7 +245,9 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
             bracketPairEmphasis: bracketPairEmphasis,
             undoManager: undoManager,
             coordinators: coordinators,
-            showMinimap: showMinimap
+            showMinimap: showMinimap,
+            reformatAtColumn: reformatAtColumn,
+            showReformattingGuide: showReformattingGuide
         )
         switch text {
         case .binding(let binding):
@@ -286,6 +304,14 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         updateEditorProperties(controller)
         updateThemeAndLanguage(controller)
         updateHighlighting(controller, coordinator: coordinator)
+
+        if controller.reformatAtColumn != reformatAtColumn {
+            controller.reformatAtColumn = reformatAtColumn
+        }
+
+        if controller.showReformattingGuide != showReformattingGuide {
+            controller.showReformattingGuide = showReformattingGuide
+        }
     }
 
     private func updateTextProperties(_ controller: TextViewController) {
@@ -369,6 +395,8 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         controller.bracketPairEmphasis == bracketPairEmphasis &&
         controller.useSystemCursor == useSystemCursor &&
         controller.showMinimap == showMinimap &&
+        controller.reformatAtColumn == reformatAtColumn &&
+        controller.showReformattingGuide == showReformattingGuide &&
         areHighlightProvidersEqual(controller: controller, coordinator: coordinator)
     }
 

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
@@ -107,7 +107,7 @@ extension TextViewController {
         ])
     }
 
-    func setUpOberservers() {
+    func setUpOnScrollChangeObserver() {
         // Layout on scroll change
         NotificationCenter.default.addObserver(
             forName: NSView.boundsDidChangeNotification,
@@ -120,7 +120,9 @@ extension TextViewController {
             self?.gutterView.needsDisplay = true
             self?.minimapXConstraint?.constant = clipView.bounds.origin.x
         }
+    }
 
+    func setUpOnScrollViewFrameChangeObserver() {
         // Layout on frame change
         NotificationCenter.default.addObserver(
             forName: NSView.frameDidChangeNotification,
@@ -132,7 +134,9 @@ extension TextViewController {
             self?.emphasisManager?.removeEmphases(for: EmphasisGroup.brackets)
             self?.updateTextInsets()
         }
+    }
 
+    func setUpTextViewFrameChangeObserver() {
         NotificationCenter.default.addObserver(
             forName: NSView.frameDidChangeNotification,
             object: textView,
@@ -147,7 +151,9 @@ extension TextViewController {
             self?.guideView?.updatePosition(in: textView)
             self?.scrollView.needsLayout = true
         }
+    }
 
+    func setUpSelectionChangedObserver() {
         NotificationCenter.default.addObserver(
             forName: TextSelectionManager.selectionChangedNotification,
             object: textView.selectionManager,
@@ -156,7 +162,9 @@ extension TextViewController {
             self?.updateCursorPosition()
             self?.emphasizeSelectionPairs()
         }
+    }
 
+    func setUpAppearanceChangedObserver() {
         NSApp.publisher(for: \.effectiveAppearance)
             .receive(on: RunLoop.main)
             .sink { [weak self] newValue in
@@ -171,6 +179,14 @@ extension TextViewController {
                 }
             }
             .store(in: &cancellables)
+    }
+
+    func setUpOberservers() {
+        setUpOnScrollChangeObserver()
+        setUpOnScrollViewFrameChangeObserver()
+        setUpTextViewFrameChangeObserver()
+        setUpSelectionChangedObserver()
+        setUpAppearanceChangedObserver()
     }
 
     func setUpKeyBindings(eventMonitor: inout Any?) {

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
@@ -68,7 +68,7 @@ extension TextViewController {
         }
 
         setUpConstraints()
-        setUpListeners()
+        setUpOberservers()
 
         textView.updateFrameIfNeeded()
 
@@ -107,7 +107,7 @@ extension TextViewController {
         ])
     }
 
-    func setUpListeners() {
+    func setUpOberservers() {
         // Layout on scroll change
         NotificationCenter.default.addObserver(
             forName: NSView.boundsDidChangeNotification,

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
@@ -28,6 +28,10 @@ extension TextViewController {
         minimapView = MinimapView(textView: textView, theme: theme)
         scrollView.addFloatingSubview(minimapView, for: .vertical)
 
+        // Add reformatting guide view
+        let guideView = ReformattingGuideView(frame: NSRect(x: 0, y: 0, width: 100, height: 100))
+        textView.addSubview(guideView)
+
         let findViewController = FindViewController(target: self, childView: scrollView)
         addChild(findViewController)
         self.findViewController = findViewController

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
@@ -12,11 +12,9 @@ extension TextViewController {
     override public func loadView() {
         super.loadView()
 
-        // Create scroll view
         scrollView = NSScrollView()
         scrollView.documentView = textView
 
-        // Create gutter view
         gutterView = GutterView(
             font: font.rulerFont,
             textColor: theme.text.color.withAlphaComponent(0.35),
@@ -27,7 +25,6 @@ extension TextViewController {
         gutterView.updateWidthIfNeeded()
         scrollView.addFloatingSubview(gutterView, for: .horizontal)
 
-        // Create reformatting guide view
         guideView = ReformattingGuideView(
             column: self.reformatAtColumn,
             isVisible: self.showReformattingGuide,
@@ -37,11 +34,9 @@ extension TextViewController {
         scrollView.addFloatingSubview(guideView, for: .vertical)
         guideView.updatePosition(in: textView)
 
-        // Create minimap view
         minimapView = MinimapView(textView: textView, theme: theme)
         scrollView.addFloatingSubview(minimapView, for: .vertical)
 
-        // Create find view
         let findViewController = FindViewController(target: self, childView: scrollView)
         addChild(findViewController)
         self.findViewController = findViewController
@@ -53,13 +48,11 @@ extension TextViewController {
             textView.setUndoManager(_undoManager)
         }
 
-        // Style views
         styleTextView()
         styleScrollView()
         styleGutterView()
         styleMinimapView()
 
-        // Set up
         setUpHighlighter()
         setUpTextFormation()
 
@@ -108,7 +101,6 @@ extension TextViewController {
     }
 
     func setUpOnScrollChangeObserver() {
-        // Layout on scroll change
         NotificationCenter.default.addObserver(
             forName: NSView.boundsDidChangeNotification,
             object: scrollView.contentView,
@@ -123,7 +115,6 @@ extension TextViewController {
     }
 
     func setUpOnScrollViewFrameChangeObserver() {
-        // Layout on frame change
         NotificationCenter.default.addObserver(
             forName: NSView.frameDidChangeNotification,
             object: scrollView.contentView,

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
@@ -58,7 +58,7 @@ extension TextViewController {
         styleScrollView()
         styleGutterView()
         styleMinimapView()
-        
+
         // Set up
         setUpHighlighter()
         setUpTextFormation()
@@ -116,7 +116,7 @@ extension TextViewController {
         ) { [weak self] notification in
             guard let clipView = notification.object as? NSClipView,
                   let textView = self?.textView else { return }
-            self?.textView.updatedViewport(self?.scrollView.documentVisibleRect ?? .zero)
+            textView.updatedViewport(self?.scrollView.documentVisibleRect ?? .zero)
             self?.gutterView.needsDisplay = true
             self?.minimapXConstraint?.constant = clipView.bounds.origin.x
         }

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+ReloadUI.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+ReloadUI.swift
@@ -19,5 +19,10 @@ extension TextViewController {
         highlighter?.invalidate()
         minimapView.updateContentViewHeight()
         minimapView.updateDocumentVisibleViewPosition()
+        
+        // Update reformatting guide position
+        if let guideView = textView.subviews.first(where: { $0 is ReformattingGuideView }) as? ReformattingGuideView {
+            guideView.updatePosition(in: textView)
+        }
     }
 }

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+ReloadUI.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+ReloadUI.swift
@@ -19,7 +19,7 @@ extension TextViewController {
         highlighter?.invalidate()
         minimapView.updateContentViewHeight()
         minimapView.updateDocumentVisibleViewPosition()
-        
+
         // Update reformatting guide position
         if let guideView = textView.subviews.first(where: { $0 is ReformattingGuideView }) as? ReformattingGuideView {
             guideView.updatePosition(in: textView)

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -16,7 +16,7 @@ import TextFormation
 ///
 /// A view controller class for managing a source editor. Uses ``CodeEditTextView/TextView`` for input and rendering,
 /// tree-sitter for syntax highlighting, and TextFormation for live editing completions.
-public class TextViewController: NSViewController {
+public class TextViewController: NSViewController { // swiftlint:disable:this type_body_length
     // swiftlint:disable:next line_length
     public static let cursorPositionUpdatedNotification: Notification.Name = .init("TextViewController.cursorPositionNotification")
 

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -237,10 +237,10 @@ public class TextViewController: NSViewController {
     /// The column at which to show the reformatting guide
     public var reformatAtColumn: Int = 80 {
         didSet {
-            if let guideView = textView.subviews.first(
-                where: { $0 is ReformattingGuideView }
-            ) as? ReformattingGuideView {
+            if let guideView = self.guideView {
                 guideView.setColumn(reformatAtColumn)
+                guideView.updatePosition(in: textView)
+                guideView.needsDisplay = true
             }
         }
     }

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -344,12 +344,6 @@ public class TextViewController: NSViewController {
 
         // Initialize guide view
         self.guideView = ReformattingGuideView(column: reformatAtColumn, isVisible: showReformattingGuide, theme: theme)
-        if let guideView = self.guideView {
-            guideView.wantsLayer = true
-            guideView.layer?.zPosition = 1
-            textView.addSubview(guideView)
-            guideView.updatePosition(in: textView)
-        }
 
         coordinators.forEach {
             $0.prepareCoordinator(controller: self)

--- a/Sources/CodeEditSourceEditor/Minimap/MinimapView.swift
+++ b/Sources/CodeEditSourceEditor/Minimap/MinimapView.swift
@@ -103,7 +103,7 @@ public class MinimapView: FlippedNSView {
         separatorView.layer?.backgroundColor = isLightMode
             ? NSColor.black.withAlphaComponent(0.1).cgColor
             : NSColor.white.withAlphaComponent(0.1).cgColor
-        
+
         super.init(frame: .zero)
 
         setUpPanGesture()

--- a/Sources/CodeEditSourceEditor/Minimap/MinimapView.swift
+++ b/Sources/CodeEditSourceEditor/Minimap/MinimapView.swift
@@ -77,6 +77,7 @@ public class MinimapView: FlippedNSView {
     public init(textView: TextView, theme: EditorTheme) {
         self.textView = textView
         self.lineRenderer = MinimapLineRenderer(textView: textView)
+        let isLightMode = theme.background.brightnessComponent > 0.5
 
         self.scrollView = ForwardingScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -92,13 +93,17 @@ public class MinimapView: FlippedNSView {
         self.documentVisibleView = NSView()
         documentVisibleView.translatesAutoresizingMaskIntoConstraints = false
         documentVisibleView.wantsLayer = true
-        documentVisibleView.layer?.backgroundColor = theme.text.color.withAlphaComponent(0.05).cgColor
+        documentVisibleView.layer?.backgroundColor = isLightMode
+            ? NSColor.black.withAlphaComponent(0.065).cgColor
+            : NSColor.white.withAlphaComponent(0.065).cgColor
 
         self.separatorView = NSView()
         separatorView.translatesAutoresizingMaskIntoConstraints = false
         separatorView.wantsLayer = true
-        separatorView.layer?.backgroundColor = NSColor.separatorColor.cgColor
-
+        separatorView.layer?.backgroundColor = isLightMode
+            ? NSColor.black.withAlphaComponent(0.1).cgColor
+            : NSColor.white.withAlphaComponent(0.1).cgColor
+        
         super.init(frame: .zero)
 
         setUpPanGesture()
@@ -171,16 +176,16 @@ public class MinimapView: FlippedNSView {
             // Constrain to all sides
             scrollView.topAnchor.constraint(equalTo: topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: separatorView.trailingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
 
             // Scrolling, but match width
-            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            contentView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
             contentViewHeightConstraint,
 
             // Y position set manually
-            documentVisibleView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            documentVisibleView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
             documentVisibleView.trailingAnchor.constraint(equalTo: trailingAnchor),
 
             // Separator on leading side
@@ -310,7 +315,13 @@ public class MinimapView: FlippedNSView {
     ///
     /// - Parameter theme: The selected theme.
     public func setTheme(_ theme: EditorTheme) {
-        documentVisibleView.layer?.backgroundColor = theme.text.color.withAlphaComponent(0.05).cgColor
+        let isLightMode = theme.background.brightnessComponent > 0.5
+        documentVisibleView.layer?.backgroundColor = isLightMode
+            ? NSColor.black.withAlphaComponent(0.065).cgColor
+            : NSColor.white.withAlphaComponent(0.065).cgColor
+        separatorView.layer?.backgroundColor = isLightMode
+            ? NSColor.black.withAlphaComponent(0.1).cgColor
+            : NSColor.white.withAlphaComponent(0.1).cgColor
         layer?.backgroundColor = theme.background.cgColor
     }
 }

--- a/Sources/CodeEditSourceEditor/Minimap/MinimapView.swift
+++ b/Sources/CodeEditSourceEditor/Minimap/MinimapView.swift
@@ -77,7 +77,7 @@ public class MinimapView: FlippedNSView {
     public init(textView: TextView, theme: EditorTheme) {
         self.textView = textView
         self.lineRenderer = MinimapLineRenderer(textView: textView)
-        let isLightMode = theme.background.brightnessComponent > 0.5
+        let isLightMode = (theme.background.usingColorSpace(.deviceRGB)?.brightnessComponent ?? 0.0) > 0.5
 
         self.scrollView = ForwardingScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/CodeEditSourceEditor/ReformattingGuide/ReformattingGuideView.swift
+++ b/Sources/CodeEditSourceEditor/ReformattingGuide/ReformattingGuideView.swift
@@ -28,6 +28,7 @@ class ReformattingGuideView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // Draw the reformatting guide line and shaded area
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
         guard isVisible else {

--- a/Sources/CodeEditSourceEditor/ReformattingGuide/ReformattingGuideView.swift
+++ b/Sources/CodeEditSourceEditor/ReformattingGuide/ReformattingGuideView.swift
@@ -1,0 +1,95 @@
+import AppKit
+import CodeEditTextView
+
+class ReformattingGuideView: NSView {
+    private let column: Int = 80
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        print("ReformattingGuideView initialized with frame: \(frameRect)")
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        print("Drawing guide view with frame: \(frame)")
+
+        // For debugging, make the guide more visible
+        NSColor.red.withAlphaComponent(0.3).setFill()
+        frame.fill()
+
+        // Draw a border around the guide for better visibility
+        NSColor.blue.setStroke()
+        let borderPath = NSBezierPath(rect: frame)
+        borderPath.lineWidth = 2.0
+        borderPath.stroke()
+
+        // Get the current theme's background color to determine if we're in light or dark mode
+        let isLightMode = NSApp.effectiveAppearance.name == .aqua
+
+        // Set the line color based on the theme
+        let lineColor = isLightMode ?
+            NSColor.black.withAlphaComponent(0.1) :
+            NSColor.white.withAlphaComponent(0.1)
+
+        // Set the shaded area color (slightly more transparent)
+        let shadedColor = isLightMode ?
+            NSColor.black.withAlphaComponent(0.05) :
+            NSColor.white.withAlphaComponent(0.05)
+
+        // Draw the vertical line (accounting for inverted Y coordinate system)
+        lineColor.setStroke()
+        let linePath = NSBezierPath()
+        linePath.move(to: NSPoint(x: frame.minX, y: frame.maxY))  // Start at top
+        linePath.line(to: NSPoint(x: frame.minX, y: frame.minY))  // Draw down to bottom
+        linePath.lineWidth = 1.0
+        linePath.stroke()
+
+        // Draw the shaded area to the right of the line
+        shadedColor.setFill()
+        let shadedRect = NSRect(
+            x: frame.minX,
+            y: frame.minY,
+            width: frame.width,
+            height: frame.height
+        )
+        shadedRect.fill()
+    }
+
+    func updatePosition(in textView: TextView) {
+        // Wait for the text view to have a valid width
+        guard textView.frame.width > 0 else {
+            print("Text view width is 0, skipping position update")
+            return
+        }
+
+        // Calculate the x position based on the font's character width and column number
+        let charWidth = textView.font.boundingRectForFont.width
+        let xPosition = CGFloat(column) * charWidth
+
+        print("Updating guide position:")
+        print("- Character width: \(charWidth)")
+        print("- Target column: \(column)")
+        print("- Calculated x position: \(xPosition)")
+        print("- Text view width: \(textView.frame.width)")
+
+        // Ensure we don't create an invalid frame
+        let maxWidth = max(0, textView.frame.width - xPosition/2)
+
+        // Update the frame to be a vertical line at column 80 with a shaded area to the right
+        let newFrame = NSRect(
+            x: 200,
+            y: 0,
+            width: maxWidth,
+            height: textView.frame.height
+        )
+        print("Setting new frame: \(newFrame)")
+
+        frame = newFrame
+        needsDisplay = true
+    }
+}


### PR DESCRIPTION
### Description

This will add a reformatting guide that is disabled by default. When enabled users will see a line drawn at a configurable column to guide them as to when and how they should reformat their code. 

### Related Issues

- #270 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<img width="1443" alt="image" src="https://github.com/user-attachments/assets/6b2bb8de-98cf-4628-bced-3c2330494676" />

<img width="1443" alt="image" src="https://github.com/user-attachments/assets/3c9ef6bb-b5a5-434e-bc0b-bf039169c271" />

<img width="1443" alt="image" src="https://github.com/user-attachments/assets/f03e8597-e383-4d8e-b3f1-328e26d818aa" />
