### PR TITLE
Add Ribbon View, Demo Fold Provider, Ribbon Toggles

### DIFF
--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,15 +10,6 @@
       }
     },
     {
-      "identity" : "codeedittextview",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
-      "state" : {
-        "revision" : "a5912e60f6bac25cd1cdf8bb532e1125b21cf7f7",
-        "version" : "0.10.1"
-      }
-    },
-    {
       "identity" : "rearrange",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/Rearrange",

--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/ContentView.swift
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/ContentView.swift
@@ -27,6 +27,7 @@ struct ContentView: View {
     @State private var settingsIsPresented: Bool = false
     @State private var treeSitterClient = TreeSitterClient()
     @AppStorage("showMinimap") private var showMinimap: Bool = true
+    @AppStorage("showFoldingRibbon") private var showFoldingRibbon: Bool = true
     @State private var indentOption: IndentOption = .spaces(count: 4)
     @AppStorage("reformatAtColumn") private var reformatAtColumn: Int = 80
     @AppStorage("showReformattingGuide") private var showReformattingGuide: Bool = false
@@ -56,7 +57,8 @@ struct ContentView: View {
                 useSystemCursor: useSystemCursor,
                 showMinimap: showMinimap,
                 reformatAtColumn: reformatAtColumn,
-                showReformattingGuide: showReformattingGuide
+                showReformattingGuide: showReformattingGuide,
+                showFoldingRibbon: showFoldingRibbon
             )
             .overlay(alignment: .bottom) {
                 StatusBar(
@@ -71,7 +73,8 @@ struct ContentView: View {
                     showMinimap: $showMinimap,
                     indentOption: $indentOption,
                     reformatAtColumn: $reformatAtColumn,
-                    showReformattingGuide: $showReformattingGuide
+                    showReformattingGuide: $showReformattingGuide,
+                    showFoldingRibbon: $showFoldingRibbon
                 )
             }
             .ignoresSafeArea()

--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/StatusBar.swift
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/StatusBar.swift
@@ -26,6 +26,7 @@ struct StatusBar: View {
     @Binding var indentOption: IndentOption
     @Binding var reformatAtColumn: Int
     @Binding var showReformattingGuide: Bool
+    @Binding var showFoldingRibbon: Bool
 
     var body: some View {
         HStack {
@@ -43,6 +44,7 @@ struct StatusBar: View {
                 .onChange(of: reformatAtColumn) { _, newValue in
                     reformatAtColumn = max(1, min(200, newValue))
                 }
+                Toggle("Show Folding Ribbon", isOn: $showFoldingRibbon)
                 if #available(macOS 14, *) {
                     Toggle("Use System Cursor", isOn: $useSystemCursor)
                 } else {

--- a/Package.resolved
+++ b/Package.resolved
@@ -10,15 +10,6 @@
       }
     },
     {
-      "identity" : "codeedittextview",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
-      "state" : {
-        "revision" : "a5912e60f6bac25cd1cdf8bb532e1125b21cf7f7",
-        "version" : "0.10.1"
-      }
-    },
-    {
       "identity" : "rearrange",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/Rearrange",

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,9 @@ let package = Package(
     dependencies: [
         // A fast, efficient, text view for code.
         .package(
-            url: "https://github.com/CodeEditApp/CodeEditTextView.git",
-            from: "0.10.1"
+            path: "../CodeEditTextView"
+//            url: "https://github.com/CodeEditApp/CodeEditTextView.git",
+//            from: "0.10.1"
         ),
         // tree-sitter languages
         .package(

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+GutterViewDelegate.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+GutterViewDelegate.swift
@@ -8,8 +8,7 @@
 import Foundation
 
 extension TextViewController: GutterViewDelegate {
-    public func gutterViewWidthDidUpdate(newWidth: CGFloat) {
-        gutterView?.frame.size.width = newWidth
-        textView?.textInsets = textViewInsets
+    public func gutterViewWidthDidUpdate() {
+        updateTextInsets()
     }
 }

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+Lifecycle.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+Lifecycle.swift
@@ -9,6 +9,13 @@ import CodeEditTextView
 import AppKit
 
 extension TextViewController {
+    override public func viewWillAppear() {
+        super.viewWillAppear()
+        // The calculation this causes cannot be done until the view knows it's final position
+        updateTextInsets()
+        minimapView.layout()
+    }
+
     override public func loadView() {
         super.loadView()
 
@@ -106,9 +113,7 @@ extension TextViewController {
             object: scrollView.contentView,
             queue: .main
         ) { [weak self] notification in
-            guard let clipView = notification.object as? NSClipView,
-                  let textView = self?.textView else { return }
-            textView.updatedViewport(self?.scrollView.documentVisibleRect ?? .zero)
+            guard let clipView = notification.object as? NSClipView else { return }
             self?.gutterView.needsDisplay = true
             self?.minimapXConstraint?.constant = clipView.bounds.origin.x
         }
@@ -120,7 +125,6 @@ extension TextViewController {
             object: scrollView.contentView,
             queue: .main
         ) { [weak self] _ in
-            self?.textView.updatedViewport(self?.scrollView.documentVisibleRect ?? .zero)
             self?.gutterView.needsDisplay = true
             self?.emphasisManager?.removeEmphases(for: EmphasisGroup.brackets)
             self?.updateTextInsets()

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+StyleViews.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+StyleViews.swift
@@ -56,6 +56,7 @@ extension TextViewController {
             gutterView.selectedLineTextColor = nil
             gutterView.selectedLineColor = .clear
         }
+        gutterView.showFoldingRibbon = showFoldingRibbon
     }
 
     /// Style the scroll view.

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -204,6 +204,13 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
         }
     }
 
+    /// Toggles the line folding ribbon in the gutter view.
+    public var showFoldingRibbon: Bool {
+        didSet {
+            gutterView?.showFoldingRibbon = showFoldingRibbon
+        }
+    }
+
     var textCoordinators: [WeakCoordinator] = []
 
     var highlighter: Highlighter?
@@ -229,7 +236,7 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
 
     package var textViewInsets: HorizontalEdgeInsets {
         HorizontalEdgeInsets(
-            left: gutterView.gutterWidth,
+            left: gutterView?.frame.width ?? 0.0,
             right: textViewTrailingInset
         )
     }
@@ -265,6 +272,9 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
         }
     }
 
+    /// A default `NSParagraphStyle` with a set `lineHeight`
+    package lazy var paragraphStyle: NSMutableParagraphStyle = generateParagraphStyle()
+
     // MARK: Init
 
     init(
@@ -291,7 +301,8 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
         coordinators: [TextViewCoordinator] = [],
         showMinimap: Bool,
         reformatAtColumn: Int = 80,
-        showReformattingGuide: Bool = false
+        showReformattingGuide: Bool = false,
+        showFoldingRibbon: Bool
     ) {
         self.language = language
         self.font = font
@@ -314,6 +325,7 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
         self.showMinimap = showMinimap
         self.reformatAtColumn = reformatAtColumn
         self.showReformattingGuide = showReformattingGuide
+        self.showFoldingRibbon = showFoldingRibbon
 
         super.init(nibName: nil, bundle: nil)
 
@@ -360,18 +372,6 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
         self.textView.setText(text)
         self.setUpHighlighter()
         self.gutterView.setNeedsDisplay(self.gutterView.frame)
-    }
-
-    // MARK: Paragraph Style
-
-    /// A default `NSParagraphStyle` with a set `lineHeight`
-    package lazy var paragraphStyle: NSMutableParagraphStyle = generateParagraphStyle()
-
-    override public func viewWillAppear() {
-        super.viewWillAppear()
-        // The calculation this causes cannot be done until the view knows it's final position
-        updateTextInsets()
-        minimapView.layout()
     }
 
     deinit {

--- a/Sources/CodeEditSourceEditor/Extensions/TextView+/TextView+TextFormation.swift
+++ b/Sources/CodeEditSourceEditor/Extensions/TextView+/TextView+TextFormation.swift
@@ -45,5 +45,6 @@ extension TextView: TextInterface {
             in: mutation.range,
             replacementLength: (mutation.string as NSString).length
         )
+        layoutManager.setNeedsLayout()
     }
 }

--- a/Sources/CodeEditSourceEditor/Gutter/GutterView.swift
+++ b/Sources/CodeEditSourceEditor/Gutter/GutterView.swift
@@ -57,6 +57,10 @@ public class GutterView: NSView {
     @Invalidating(.display)
     var backgroundEdgeInsets: EdgeInsets = EdgeInsets(leading: 0, trailing: 8)
 
+    /// The leading padding for the folding ribbon from the line numbers.
+    @Invalidating(.display)
+    var foldingRibbonPadding: CGFloat = 4
+
     @Invalidating(.display)
     var backgroundColor: NSColor? = NSColor.controlBackgroundColor
 
@@ -101,7 +105,11 @@ public class GutterView: NSView {
 
     /// Syntax helper for determining the required space for the folding ribbon.
     private var foldingRibbonWidth: CGFloat {
-        if foldingRibbon.isHidden { 0.0 } else { FoldingRibbonView.width }
+        if foldingRibbon.isHidden {
+            0.0
+        } else {
+            FoldingRibbonView.width + foldingRibbonPadding
+        }
     }
 
     /// The gutter's y positions start at the top of the document and increase as it moves down the screen.
@@ -117,7 +125,7 @@ public class GutterView: NSView {
         set {
             super.frame = newValue
             foldingRibbon.frame = NSRect(
-                x: newValue.width - edgeInsets.trailing - foldingRibbonWidth,
+                x: newValue.width - edgeInsets.trailing - foldingRibbonWidth + foldingRibbonPadding,
                 y: 0.0,
                 width: foldingRibbonWidth,
                 height: newValue.height
@@ -138,7 +146,7 @@ public class GutterView: NSView {
         self.textView = textView
         self.delegate = delegate
 
-        foldingRibbon = FoldingRibbonView(textView: textView, levelProvider: nil)
+        foldingRibbon = FoldingRibbonView(textView: textView, foldProvider: nil)
 
         super.init(frame: .zero)
         clipsToBounds = true
@@ -196,7 +204,7 @@ public class GutterView: NSView {
     private func drawBackground(_ context: CGContext, dirtyRect: NSRect) {
         guard let backgroundColor else { return }
         let minX = max(backgroundEdgeInsets.leading, dirtyRect.minX)
-        let maxX = min(frame.width - backgroundEdgeInsets.trailing, dirtyRect.maxX)
+        let maxX = min(frame.width - backgroundEdgeInsets.trailing - foldingRibbonWidth, dirtyRect.maxX)
         let width = maxX - minX
 
         context.saveGState()

--- a/Sources/CodeEditSourceEditor/Gutter/GutterView.swift
+++ b/Sources/CodeEditSourceEditor/Gutter/GutterView.swift
@@ -10,7 +10,7 @@ import CodeEditTextView
 import CodeEditTextViewObjC
 
 public protocol GutterViewDelegate: AnyObject {
-    func gutterViewWidthDidUpdate(newWidth: CGFloat)
+    func gutterViewWidthDidUpdate()
 }
 
 /// The gutter view displays line numbers that match the text view's line indexes.
@@ -69,12 +69,17 @@ public class GutterView: NSView {
     @Invalidating(.display)
     var selectedLineColor: NSColor = NSColor.selectedTextBackgroundColor.withSystemEffect(.disabled)
 
-    /// The required width of the entire gutter, including padding.
-    private(set) public var gutterWidth: CGFloat = 0
+    /// Toggle the visibility of the line fold decoration.
+    @Invalidating(.display)
+    public var showFoldingRibbon: Bool = true {
+        didSet {
+            foldingRibbon.isHidden = !showFoldingRibbon
+        }
+    }
 
     private weak var textView: TextView?
     private weak var delegate: GutterViewDelegate?
-    private var maxWidth: CGFloat = 0
+    private var maxLineNumberWidth: CGFloat = 0
     /// The maximum number of digits found for a line number.
     private var maxLineLength: Int = 0
 
@@ -91,8 +96,33 @@ public class GutterView: NSView {
         fontLineHeight = (ascent + descent + leading)
     }
 
+    /// The view that draws the fold decoration in the gutter.
+    private var foldingRibbon: FoldingRibbonView
+
+    /// Syntax helper for determining the required space for the folding ribbon.
+    private var foldingRibbonWidth: CGFloat {
+        if foldingRibbon.isHidden { 0.0 } else { FoldingRibbonView.width }
+    }
+
+    /// The gutter's y positions start at the top of the document and increase as it moves down the screen.
     override public var isFlipped: Bool {
         true
+    }
+
+    /// We override this variable so we can update the ``foldingRibbon``'s frame to match the gutter.
+    override public var frame: NSRect {
+        get {
+            super.frame
+        }
+        set {
+            super.frame = newValue
+            foldingRibbon.frame = NSRect(
+                x: newValue.width - edgeInsets.trailing - foldingRibbonWidth,
+                y: 0.0,
+                width: foldingRibbonWidth,
+                height: newValue.height
+            )
+        }
     }
 
     public init(
@@ -108,12 +138,16 @@ public class GutterView: NSView {
         self.textView = textView
         self.delegate = delegate
 
+        foldingRibbon = FoldingRibbonView(textView: textView, levelProvider: nil)
+
         super.init(frame: .zero)
         clipsToBounds = true
         wantsLayer = true
         layerContentsRedrawPolicy = .onSetNeedsDisplay
         translatesAutoresizingMaskIntoConstraints = false
         layer?.masksToBounds = true
+
+        addSubview(foldingRibbon)
 
         NotificationCenter.default.addObserver(
             forName: TextSelectionManager.selectionChangedNotification,
@@ -124,22 +158,17 @@ public class GutterView: NSView {
         }
     }
 
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-    }
-
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    /// Updates the width of the gutter if needed.
+    /// Updates the width of the gutter if needed to match the maximum line number found as well as the folding ribbon.
     func updateWidthIfNeeded() {
         guard let textView else { return }
         let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: textColor
         ]
-        let originalMaxWidth = maxWidth
         // Reserve at least 3 digits of space no matter what
         let lineStorageDigits = max(3, String(textView.layoutManager.lineCount).count)
 
@@ -149,27 +178,36 @@ public class GutterView: NSView {
                 NSAttributedString(string: String(repeating: "0", count: lineStorageDigits), attributes: attributes)
             )
             let width = CTLineGetTypographicBounds(maxCtLine, nil, nil, nil)
-            maxWidth = max(maxWidth, width)
+            maxLineNumberWidth = max(maxLineNumberWidth, width)
             maxLineLength = lineStorageDigits
         }
 
-        if originalMaxWidth != maxWidth {
-            gutterWidth = maxWidth + edgeInsets.horizontal
-            delegate?.gutterViewWidthDidUpdate(newWidth: maxWidth + edgeInsets.horizontal)
+        let newWidth = maxLineNumberWidth + edgeInsets.horizontal + foldingRibbonWidth
+        if frame.size.width != newWidth {
+            frame.size.width = newWidth
+            delegate?.gutterViewWidthDidUpdate()
         }
     }
 
-    private func drawBackground(_ context: CGContext) {
+    /// Fills the gutter background color.
+    /// - Parameters:
+    ///   - context: The drawing context to draw in.
+    ///   - dirtyRect: A rect to draw in, received from ``draw(_:)``.
+    private func drawBackground(_ context: CGContext, dirtyRect: NSRect) {
         guard let backgroundColor else { return }
-        let xPos = backgroundEdgeInsets.leading
-        let width = gutterWidth - backgroundEdgeInsets.trailing
+        let minX = max(backgroundEdgeInsets.leading, dirtyRect.minX)
+        let maxX = min(frame.width - backgroundEdgeInsets.trailing, dirtyRect.maxX)
+        let width = maxX - minX
 
         context.saveGState()
         context.setFillColor(backgroundColor.cgColor)
-        context.fill(CGRect(x: xPos, y: 0, width: width, height: frame.height))
+        context.fill(CGRect(x: minX, y: dirtyRect.minY, width: width, height: dirtyRect.height))
         context.restoreGState()
     }
 
+    /// Draws selected line backgrounds from the text view's selection manager into the gutter view, making the
+    /// selection background appear seamless between the gutter and text view.
+    /// - Parameter context: The drawing context to use.
     private func drawSelectedLines(_ context: CGContext) {
         guard let textView = textView,
               let selectionManager = textView.selectionManager,
@@ -183,7 +221,7 @@ public class GutterView: NSView {
         context.setFillColor(selectedLineColor.cgColor)
 
         let xPos = backgroundEdgeInsets.leading
-        let width = gutterWidth - backgroundEdgeInsets.trailing
+        let width = frame.width - backgroundEdgeInsets.trailing
 
         for selection in selectionManager.textSelections where selection.range.isEmpty {
             guard let line = textView.layoutManager.textLineForOffset(selection.range.location),
@@ -205,7 +243,11 @@ public class GutterView: NSView {
         context.restoreGState()
     }
 
-    private func drawLineNumbers(_ context: CGContext) {
+    /// Draw line numbers in the gutter, limited to a drawing rect.
+    /// - Parameters:
+    ///   - context: The drawing context to draw in.
+    ///   - dirtyRect: A rect to draw in, received from ``draw(_:)``.
+    private func drawLineNumbers(_ context: CGContext, dirtyRect: NSRect) {
         guard let textView = textView else { return }
         var attributes: [NSAttributedString.Key: Any] = [.font: font]
 
@@ -219,9 +261,10 @@ public class GutterView: NSView {
         }
 
         context.saveGState()
+        context.clip(to: dirtyRect)
 
         context.textMatrix = CGAffineTransform(scaleX: 1, y: -1)
-        for linePosition in textView.layoutManager.visibleLines() {
+        for linePosition in textView.layoutManager.linesStartingAt(dirtyRect.minY, until: dirtyRect.maxY) {
             if selectionRangeMap.intersects(integersIn: linePosition.range) {
                 attributes[.foregroundColor] = selectedLineTextColor ?? textColor
             } else {
@@ -238,7 +281,7 @@ public class GutterView: NSView {
 
             let yPos = linePosition.yPos + ascent + (fragment?.heightDifference ?? 0)/2 + fontHeightDifference
             // Leading padding + (width - linewidth)
-            let xPos = edgeInsets.leading + (maxWidth - lineNumberWidth)
+            let xPos = edgeInsets.leading + (maxLineNumberWidth - lineNumberWidth)
 
             ContextSetHiddenSmoothingStyle(context, 16)
 
@@ -249,18 +292,20 @@ public class GutterView: NSView {
         context.restoreGState()
     }
 
+    override public func setNeedsDisplay(_ invalidRect: NSRect) {
+        updateWidthIfNeeded()
+        super.setNeedsDisplay(invalidRect)
+    }
+
     override public func draw(_ dirtyRect: NSRect) {
         guard let context = NSGraphicsContext.current?.cgContext else {
             return
         }
-        CATransaction.begin()
-        superview?.clipsToBounds = false
-        superview?.layer?.masksToBounds = false
-        updateWidthIfNeeded()
-        drawBackground(context)
+        context.saveGState()
+        drawBackground(context, dirtyRect: dirtyRect)
         drawSelectedLines(context)
-        drawLineNumbers(context)
-        CATransaction.commit()
+        drawLineNumbers(context, dirtyRect: dirtyRect)
+        context.restoreGState()
     }
 
     deinit {

--- a/Sources/CodeEditSourceEditor/Gutter/LineFolding/DefaultProviders/IndentationLineFoldProvider.swift
+++ b/Sources/CodeEditSourceEditor/Gutter/LineFolding/DefaultProviders/IndentationLineFoldProvider.swift
@@ -1,0 +1,34 @@
+//
+//  IndentationLineFoldProvider.swift
+//  CodeEditSourceEditor
+//
+//  Created by Khan Winter on 5/8/25.
+//
+
+import AppKit
+import CodeEditTextView
+
+final class IndentationLineFoldProvider: LineFoldProvider {
+    func foldLevelAtLine(_ lineNumber: Int, layoutManager: TextLayoutManager, textStorage: NSTextStorage) -> Int? {
+        guard let linePosition = layoutManager.textLineForIndex(lineNumber),
+              let indentLevel = indentLevelForPosition(linePosition, textStorage: textStorage) else {
+            return nil
+        }
+
+        return indentLevel
+    }
+
+    private func indentLevelForPosition(
+        _ position: TextLineStorage<TextLine>.TextLinePosition,
+        textStorage: NSTextStorage
+    ) -> Int? {
+        guard let substring = textStorage.substring(from: position.range) else {
+            return nil
+        }
+
+        return substring.utf16 // Keep NSString units
+            .enumerated()
+            .first(where: { UnicodeScalar($0.element)?.properties.isWhitespace != true })?
+            .offset
+    }
+}

--- a/Sources/CodeEditSourceEditor/Gutter/LineFolding/FoldRange.swift
+++ b/Sources/CodeEditSourceEditor/Gutter/LineFolding/FoldRange.swift
@@ -1,0 +1,25 @@
+//
+//  FoldRange.swift
+//  CodeEditSourceEditor
+//
+//  Created by Khan Winter on 5/7/25.
+//
+
+import Foundation
+
+/// Represents a recursive folded range
+class FoldRange {
+    var lineRange: ClosedRange<Int>
+    var range: NSRange
+    /// Ordered array of ranges that are nested in this fold.
+    var subFolds: [FoldRange]
+
+    weak var parent: FoldRange?
+
+    init(lineRange: ClosedRange<Int>, range: NSRange, parent: FoldRange?, subFolds: [FoldRange]) {
+        self.lineRange = lineRange
+        self.range = range
+        self.subFolds = subFolds
+        self.parent = parent
+    }
+}

--- a/Sources/CodeEditSourceEditor/Gutter/LineFolding/FoldingRibbonView.swift
+++ b/Sources/CodeEditSourceEditor/Gutter/LineFolding/FoldingRibbonView.swift
@@ -1,0 +1,193 @@
+//
+//  FoldingRibbonView.swift
+//  CodeEditSourceEditor
+//
+//  Created by Khan Winter on 5/6/25.
+//
+
+import Foundation
+import AppKit
+import CodeEditTextView
+
+/// Displays the code folding ribbon in the ``GutterView``.
+///
+/// This view draws its contents
+class FoldingRibbonView: NSView {
+    static let width: CGFloat = 7.0
+
+    private var model: LineFoldingModel
+    private var hoveringLine: Int?
+
+    @Invalidating(.display)
+    var backgroundColor: NSColor = NSColor.controlBackgroundColor
+
+    @Invalidating(.display)
+    var markerColor = CGColor(gray: 0.0, alpha: 0.1)
+
+    override public var isFlipped: Bool {
+        true
+    }
+
+    init(textView: TextView, levelProvider: LineFoldProvider?) {
+        self.model = LineFoldingModel(
+            textView: textView,
+            levelProvider: levelProvider
+        )
+        super.init(frame: .zero)
+        layerContentsRedrawPolicy = .onSetNeedsDisplay
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func updateTrackingAreas() {
+        trackingAreas.forEach(removeTrackingArea)
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseMoved, .activeInKeyWindow],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        let pointInView = convert(event.locationInWindow, from: nil)
+        hoveringLine = model.textView?.layoutManager.textLineForPosition(pointInView.y)?.index
+    }
+
+    struct FoldMarkerDrawingContext {
+        let range: ClosedRange<Int>
+        let depth: UInt
+        let hoveringLine: Int?
+
+        func increment() -> FoldMarkerDrawingContext {
+            FoldMarkerDrawingContext(
+                range: range,
+                depth: depth + 1,
+                hoveringLine: isHovering() ? nil : hoveringLine
+            )
+        }
+
+        func isHovering() -> Bool {
+            guard let hoveringLine else {
+                return false
+            }
+            return range.contains(hoveringLine)
+        }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let context = NSGraphicsContext.current?.cgContext,
+                let layoutManager = model.textView?.layoutManager else {
+            return
+        }
+
+        context.saveGState()
+        context.clip(to: dirtyRect)
+
+        // Find the visible lines in the rect AppKit is asking us to draw.
+        guard let rangeStart = layoutManager.textLineForPosition(dirtyRect.minY),
+              let rangeEnd = layoutManager.textLineForPosition(dirtyRect.maxY) else {
+            return
+        }
+        let lineRange = rangeStart.index...rangeEnd.index
+
+        context.setFillColor(markerColor)
+        let folds = model.folds(in: lineRange)
+        for fold in folds {
+            drawFoldMarker(
+                fold,
+                markerContext: FoldMarkerDrawingContext(range: lineRange, depth: 0, hoveringLine: hoveringLine),
+                in: context,
+                using: layoutManager
+            )
+        }
+
+        context.restoreGState()
+    }
+    
+    /// Draw a single fold marker for a fold.
+    ///
+    /// Ensure the correct fill color is set on the drawing context before calling.
+    ///
+    /// - Parameters:
+    ///   - fold: The fold to draw.
+    ///   - markerContext: The context in which the fold is being drawn, including the depth and if a line is
+    ///                    being hovered.
+    ///   - context: The drawing context to use.
+    ///   - layoutManager: A layout manager used to retrieve position information for lines.
+    private func drawFoldMarker(
+        _ fold: FoldRange,
+        markerContext: FoldMarkerDrawingContext,
+        in context: CGContext,
+        using layoutManager: TextLayoutManager
+    ) {
+        guard let minYPosition = layoutManager.textLineForIndex(fold.lineRange.lowerBound)?.yPos,
+              let maxPosition = layoutManager.textLineForIndex(fold.lineRange.upperBound) else {
+            return
+        }
+
+        let maxYPosition = maxPosition.yPos + maxPosition.height
+
+        // TODO: Draw a single line when folds are adjacent
+
+        if markerContext.isHovering() {
+            // TODO: Handle hover state
+        } else {
+            let plainRect = NSRect(x: 0, y: minYPosition + 1, width: 7, height: maxYPosition - minYPosition - 2)
+            let roundedRect = NSBezierPath(roundedRect: plainRect, xRadius: 3.5, yRadius: 3.5)
+
+            context.addPath(roundedRect.cgPathFallback)
+            context.drawPath(using: .fill)
+
+            // Add small white line if we're overlapping with other markers
+            if markerContext.depth != 0 {
+                drawOutline(
+                    minYPosition: minYPosition,
+                    maxYPosition: maxYPosition,
+                    originalPath: roundedRect,
+                    in: context
+                )
+            }
+        }
+
+        // Draw subfolds
+        for subFold in fold.subFolds.filter({ $0.lineRange.overlaps(markerContext.range) }) {
+            drawFoldMarker(subFold, markerContext: markerContext.increment(), in: context, using: layoutManager)
+        }
+    }
+    
+    /// Draws a rounded outline for a rectangle, creating the small, light, outline around each fold indicator.
+    ///
+    /// This function does not change fill colors for the given context.
+    ///
+    /// - Parameters:
+    ///   - minYPosition: The minimum y position of the rectangle to outline.
+    ///   - maxYPosition: The maximum y position of the rectangle to outline.
+    ///   - originalPath: The original bezier path for the rounded rectangle.
+    ///   - context: The context to draw in.
+    private func drawOutline(
+        minYPosition: CGFloat,
+        maxYPosition: CGFloat,
+        originalPath: NSBezierPath,
+        in context: CGContext
+    ) {
+        context.saveGState()
+
+        let plainRect = NSRect(x: -0.5, y: minYPosition, width: 8, height: maxYPosition - minYPosition)
+        let roundedRect = NSBezierPath(roundedRect: plainRect, xRadius: 4, yRadius: 4)
+
+        let combined = CGMutablePath()
+        combined.addPath(roundedRect.cgPathFallback)
+        combined.addPath(originalPath.cgPathFallback)
+
+        context.clip(to: CGRect(x: 0, y: minYPosition, width: 7, height: maxYPosition - minYPosition))
+        context.addPath(combined)
+        context.setFillColor(CGColor(gray: 1.0, alpha: 0.4))
+        context.drawPath(using: .eoFill)
+
+        context.restoreGState()
+    }
+}

--- a/Sources/CodeEditSourceEditor/Gutter/LineFolding/FoldingRibbonView.swift
+++ b/Sources/CodeEditSourceEditor/Gutter/LineFolding/FoldingRibbonView.swift
@@ -9,47 +9,6 @@ import Foundation
 import AppKit
 import CodeEditTextView
 
-final class IndentationLineFoldProvider: LineFoldProvider {
-    func foldLevelAtLine(_ lineNumber: Int, layoutManager: TextLayoutManager, textStorage: NSTextStorage) -> Int? {
-        guard let linePosition = layoutManager.textLineForIndex(lineNumber),
-              let indentLevel = indentLevelForPosition(linePosition, textStorage: textStorage) else {
-            return nil
-        }
-
-        //        if let precedingLinePosition = layoutManager.textLineForIndex(lineNumber - 1),
-        //           let precedingIndentLevel = indentLevelForPosition(precedingLinePosition, textStorage: textStorage) {
-        //            if precedingIndentLevel > indentLevel {
-        //                return precedingIndentLevel
-        //            }
-        //        }
-        //
-        //        if let nextLinePosition = layoutManager.textLineForIndex(lineNumber + 1),
-        //           let nextIndentLevel = indentLevelForPosition(nextLinePosition, textStorage: textStorage) {
-        //            if nextIndentLevel > indentLevel {
-        //                return nextIndentLevel
-        //            }
-        //        }
-
-        return indentLevel
-    }
-
-    private func indentLevelForPosition(
-        _ position: TextLineStorage<TextLine>.TextLinePosition,
-        textStorage: NSTextStorage
-    ) -> Int? {
-        guard let substring = textStorage.substring(from: position.range) else {
-            return nil
-        }
-
-        return substring.utf16 // Keep NSString units
-            .enumerated()
-            .first(where: { UnicodeScalar($0.element)?.properties.isWhitespace != true })?
-            .offset
-    }
-}
-
-let buh = IndentationLineFoldProvider()
-
 /// Displays the code folding ribbon in the ``GutterView``.
 ///
 /// This view draws its contents
@@ -93,7 +52,7 @@ class FoldingRibbonView: NSView {
     init(textView: TextView, foldProvider: LineFoldProvider?) {
         self.model = LineFoldingModel(
             textView: textView,
-            foldProvider: buh
+            foldProvider: foldProvider
         )
         super.init(frame: .zero)
         layerContentsRedrawPolicy = .onSetNeedsDisplay

--- a/Sources/CodeEditSourceEditor/Gutter/LineFolding/FoldingRibbonView.swift
+++ b/Sources/CodeEditSourceEditor/Gutter/LineFolding/FoldingRibbonView.swift
@@ -9,6 +9,9 @@ import Foundation
 import AppKit
 import CodeEditTextView
 
+#warning("Replace before release")
+fileprivate let demoFoldProvider = IndentationLineFoldProvider()
+
 /// Displays the code folding ribbon in the ``GutterView``.
 ///
 /// This view draws its contents
@@ -50,9 +53,10 @@ class FoldingRibbonView: NSView {
     }
 
     init(textView: TextView, foldProvider: LineFoldProvider?) {
+        #warning("Replace before release")
         self.model = LineFoldingModel(
             textView: textView,
-            foldProvider: foldProvider
+            foldProvider: foldProvider ?? demoFoldProvider
         )
         super.init(frame: .zero)
         layerContentsRedrawPolicy = .onSetNeedsDisplay

--- a/Sources/CodeEditSourceEditor/Gutter/LineFolding/LineFoldProvider.swift
+++ b/Sources/CodeEditSourceEditor/Gutter/LineFolding/LineFoldProvider.swift
@@ -1,0 +1,13 @@
+//
+//  LineFoldProvider.swift
+//  CodeEditSourceEditor
+//
+//  Created by Khan Winter on 5/7/25.
+//
+
+import AppKit
+import CodeEditTextView
+
+protocol LineFoldProvider: AnyObject {
+    func foldLevelAtLine(_ lineNumber: Int, layoutManager: TextLayoutManager, textStorage: NSTextStorage) -> Int?
+}

--- a/Sources/CodeEditSourceEditor/Gutter/LineFolding/LineFoldingModel.swift
+++ b/Sources/CodeEditSourceEditor/Gutter/LineFolding/LineFoldingModel.swift
@@ -1,0 +1,151 @@
+//
+//  LineFoldingModel.swift
+//  CodeEditSourceEditor
+//
+//  Created by Khan Winter on 5/7/25.
+//
+
+import AppKit
+import CodeEditTextView
+
+/// # Basic Premise
+///
+/// We need to update, delete, or add fold ranges in the invalidated lines.
+///
+/// # Implementation
+///
+/// - For each line in the document, put its indent level into a list.
+/// - Loop through the list, creating nested folds as indents go up and down.
+///
+class LineFoldingModel: NSObject, NSTextStorageDelegate {
+    /// An ordered tree of fold ranges in a document. Can be traversed using ``FoldRange/parent``
+    /// and ``FoldRange/subFolds``.
+    private var foldCache: [FoldRange] = []
+
+    weak var levelProvider: LineFoldProvider?
+    weak var textView: TextView?
+
+    init(textView: TextView, levelProvider: LineFoldProvider?) {
+        self.textView = textView
+        self.levelProvider = levelProvider
+        super.init()
+        textView.addStorageDelegate(self)
+        buildFoldsForDocument()
+    }
+
+    func folds(in lineRange: ClosedRange<Int>) -> [FoldRange] {
+        foldCache.filter({ $0.lineRange.overlaps(lineRange) })
+    }
+
+    func buildFoldsForDocument() {
+        guard let textView, let levelProvider else { return }
+        foldCache.removeAll(keepingCapacity: true)
+
+        var currentFold: FoldRange?
+        var currentDepth: Int = 0
+        for linePosition in textView.layoutManager.linesInRange(textView.documentRange) {
+            guard let foldDepth = levelProvider.foldLevelAtLine(
+                linePosition.index,
+                layoutManager: textView.layoutManager,
+                textStorage: textView.textStorage
+            ) else {
+                continue
+            }
+            // Start a new fold
+            if foldDepth > currentDepth {
+                let newFold = FoldRange(
+                    lineRange: (linePosition.index - 1)...(linePosition.index - 1),
+                    range: .zero,
+                    parent: currentFold,
+                    subFolds: []
+                )
+
+                if currentDepth == 0 {
+                    foldCache.append(newFold)
+                }
+                currentFold?.subFolds.append(newFold)
+                currentFold = newFold
+            } else if foldDepth < currentDepth {
+                // End this fold
+                if let fold = currentFold {
+                    fold.lineRange = fold.lineRange.lowerBound...linePosition.index
+
+                    if foldDepth == 0 {
+                        currentFold = nil
+                    }
+                }
+                currentFold = currentFold?.parent
+            }
+
+            currentDepth = foldDepth
+        }
+    }
+
+    func invalidateLine(lineNumber: Int) {
+        // TODO: Check if we need to rebuild, or even better, incrementally update the tree.
+
+        // Temporary
+        buildFoldsForDocument()
+    }
+
+    func textStorage(
+        _ textStorage: NSTextStorage,
+        didProcessEditing editedMask: NSTextStorageEditActions,
+        range editedRange: NSRange,
+        changeInLength delta: Int
+    ) {
+        guard editedMask.contains(.editedCharacters),
+              let lineNumber = textView?.layoutManager.textLineForOffset(editedRange.location)?.index else {
+            return
+        }
+        invalidateLine(lineNumber: lineNumber)
+    }
+}
+
+// MARK: - Search Folds
+
+private extension LineFoldingModel {
+    /// Finds the deepest cached depth of the fold for a line number.
+    /// - Parameter lineNumber: The line number to query, zero-indexed.
+    /// - Returns: The deepest cached depth of the fold if it was found.
+    func getCachedDepthAt(lineNumber: Int) -> Int? {
+        return findCachedFoldAt(lineNumber: lineNumber)?.depth
+    }
+
+    /// Finds the deepest cached fold and depth of the fold for a line number.
+    /// - Parameter lineNumber: The line number to query, zero-indexed.
+    /// - Returns: The deepest cached fold and depth of the fold if it was found.
+    func findCachedFoldAt(lineNumber: Int) -> (range: FoldRange, depth: Int)? {
+        binarySearchFoldsArray(lineNumber: lineNumber, folds: foldCache, currentDepth: 0)
+    }
+
+    /// A generic function for searching an ordered array of fold ranges.
+    /// - Returns: The found range and depth it was found at, if it exists.
+    func binarySearchFoldsArray(
+        lineNumber: Int,
+        folds: borrowing [FoldRange],
+        currentDepth: Int
+    ) -> (range: FoldRange, depth: Int)? {
+        var low = 0
+        var high = folds.count - 1
+
+        while low <= high {
+            let mid = (low + high) / 2
+            let fold = folds[mid]
+
+            if fold.lineRange.contains(lineNumber) {
+                // Search deeper into subFolds, if any
+                return binarySearchFoldsArray(
+                    lineNumber: lineNumber,
+                    folds: fold.subFolds,
+                    currentDepth: currentDepth + 1
+                ) ?? (fold, currentDepth)
+            } else if lineNumber < fold.lineRange.lowerBound {
+                high = mid - 1
+            } else {
+                low = mid + 1
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/CodeEditSourceEditor/Minimap/MinimapLineRenderer.swift
+++ b/Sources/CodeEditSourceEditor/Minimap/MinimapLineRenderer.swift
@@ -21,7 +21,7 @@ final class MinimapLineRenderer: TextLayoutManagerRenderDelegate {
         range: NSRange,
         stringRef: NSTextStorage,
         markedRanges: MarkedRanges?,
-        breakStrategy: LineBreakStrategy
+        attachments: [AnyTextAttachment]
     ) {
         let maxWidth: CGFloat = if let textView, textView.wrapLines {
             textView.layoutManager.maxLineLayoutWidth
@@ -34,7 +34,7 @@ final class MinimapLineRenderer: TextLayoutManagerRenderDelegate {
             range: range,
             stringRef: stringRef,
             markedRanges: markedRanges,
-            breakStrategy: breakStrategy
+            attachments: []
         )
 
         // Make all fragments 2px tall
@@ -62,6 +62,12 @@ final class MinimapLineRenderer: TextLayoutManagerRenderDelegate {
 
     func characterXPosition(in lineFragment: LineFragment, for offset: Int) -> CGFloat {
         // Offset is relative to the whole line, the CTLine is too.
-        return 8 + (CGFloat(offset - CTLineGetStringRange(lineFragment.ctLine).location) * 1.5)
+        guard let content = lineFragment.contents.first else { return 0.0 }
+        switch content.data {
+        case .text(let ctLine):
+            return 8 + (CGFloat(offset - CTLineGetStringRange(ctLine).location) * 1.5)
+        case .attachment:
+            return 0.0
+        }
     }
 }

--- a/Tests/CodeEditSourceEditorTests/LineFoldingTests/LineFoldingModelTests.swift
+++ b/Tests/CodeEditSourceEditorTests/LineFoldingTests/LineFoldingModelTests.swift
@@ -1,0 +1,55 @@
+//
+//  LineFoldingModelTests.swift
+//  CodeEditSourceEditor
+//
+//  Created by Khan Winter on 5/8/25.
+//
+
+import Testing
+import AppKit
+import CodeEditTextView
+@testable import CodeEditSourceEditor
+
+@Suite
+@MainActor
+struct LineFoldingModelTests {
+    /// Makes a fold pattern that increases until halfway through the document then goes back to zero.
+    class HillPatternFoldProvider: LineFoldProvider {
+        func foldLevelAtLine(_ lineNumber: Int, layoutManager: TextLayoutManager, textStorage: NSTextStorage) -> Int? {
+            let halfLineCount = (layoutManager.lineCount / 2) - 1
+
+            return if lineNumber > halfLineCount {
+                layoutManager.lineCount - 2 - lineNumber
+            } else {
+                lineNumber
+            }
+        }
+    }
+
+    let textView: TextView
+    let model: LineFoldingModel
+
+    init() {
+        textView = TextView(string: "A\nB\nC\nD\nE\nF\n")
+        textView.frame = NSRect(x: 0, y: 0, width: 1000, height: 1000)
+        textView.updatedViewport(NSRect(x: 0, y: 0, width: 1000, height: 1000))
+        model = LineFoldingModel(textView: textView, foldProvider: nil)
+    }
+
+    /// A little unintuitive but we only expect two folds with this. Our provider goes 0-1-2-2-1-0, but we don't
+    /// make folds for indent level 0. We also expect folds to start on the lines *before* the indent increases and
+    /// after it decreases, so the fold covers the start/end of the region being folded.
+    @Test
+    func buildFoldsForDocument() throws {
+        let provider = HillPatternFoldProvider()
+        model.foldProvider = provider
+
+        model.buildFoldsForDocument()
+
+        let fold = try #require(model.getFolds(in: 0...5).first)
+        #expect(fold.lineRange == 0...5)
+
+        let innerFold = try #require(fold.subFolds.first)
+        #expect(innerFold.lineRange == 1...4)
+    }
+}

--- a/Tests/CodeEditSourceEditorTests/Mock.swift
+++ b/Tests/CodeEditSourceEditorTests/Mock.swift
@@ -64,7 +64,8 @@ enum Mock {
             letterSpacing: 1.0,
             useSystemCursor: false,
             bracketPairEmphasis: .flash,
-            showMinimap: true
+            showMinimap: true,
+            showFoldingRibbon: true
         )
     }
 

--- a/Tests/CodeEditSourceEditorTests/TextViewControllerTests.swift
+++ b/Tests/CodeEditSourceEditorTests/TextViewControllerTests.swift
@@ -484,12 +484,12 @@ final class TextViewControllerTests: XCTestCase {
         controller.showFoldingRibbon = false
         XCTAssertFalse(controller.gutterView.showFoldingRibbon)
         controller.gutterView.updateWidthIfNeeded() // Would be called on a display pass
-        let noRibbonWidth = controller.gutterView.gutterWidth
+        let noRibbonWidth = controller.gutterView.frame.width
 
         controller.showFoldingRibbon = true
         XCTAssertTrue(controller.gutterView.showFoldingRibbon)
         controller.gutterView.updateWidthIfNeeded() // Would be called on a display pass
-        XCTAssertEqual(controller.gutterView.gutterWidth, noRibbonWidth + 7.0)
+        XCTAssertEqual(controller.gutterView.frame.width, noRibbonWidth + 7.0)
     }
 }
 


### PR DESCRIPTION
### Description

> [!NOTE]
> For reviewers, this is merging into the dev branch. These changes require the version of CETV in [this PR](https://github.com/CodeEditApp/CodeEditTextView/pull/93). Please pull those changes locally and test using that.

> [!NOTE]
> I'll be making some TODOs in the tracking issue #43 for things that aren't included here. Like the overlapping folds UI issue. 

Adds the first version of the code folding ribbon, with a very basic folding model.

This is mostly a UI change. It includes changes to the gutter, and a new view for displaying folds. The model and related demo fold provider should be considered incomplete and only for demo purposes.

This also doesn't implement the hover state yet. Just a very basic outline of everything.

### Related Issues

* #43 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Light mode.
![Screenshot 2025-05-07 at 3 22 17 PM](https://github.com/user-attachments/assets/a9b7838f-6bea-4bb4-bd61-b72175c76788)

Dark Mode.
![Screenshot 2025-05-08 at 10 12 45 AM](https://github.com/user-attachments/assets/fb8e3264-71ec-40aa-9d62-7d4a74c15343)

Folds are transparent for scrolling text.
![Screenshot 2025-05-08 at 10 08 35 AM](https://github.com/user-attachments/assets/17a1623c-3e8e-40a5-ace3-6adbe8e13320)
