### PR TITLE
Add the ability to move selected lines up and down

### DIFF
--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
@@ -201,6 +201,7 @@ extension TextViewController {
 
     func handleCommand(event: NSEvent, modifierFlags: UInt) -> NSEvent? {
         let commandKey = NSEvent.ModifierFlags.command.rawValue
+        let commandOptionKey = NSEvent.ModifierFlags.command.union(.option).rawValue
 
         switch (modifierFlags, event.charactersIgnoringModifiers) {
         case (commandKey, "/"):
@@ -209,8 +210,14 @@ extension TextViewController {
         case (commandKey, "["):
             handleIndent(inwards: true)
             return nil
+        case (commandOptionKey, "["):
+            moveLinesUp()
+            return nil
         case (commandKey, "]"):
             handleIndent()
+            return nil
+        case (commandOptionKey, "]"):
+            moveLinesDown()
             return nil
         case (commandKey, "f"):
             _ = self.textView.resignFirstResponder()

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+MoveLines.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+MoveLines.swift
@@ -17,12 +17,12 @@ extension TextViewController {
         textView.editSelections { textView, selection in
             guard let lineIndexes = getOverlappingLines(for: selection.range) else { return }
             let lowerBound = lineIndexes.lowerBound
-            guard
-                lowerBound > .zero,
-                let prevLineInfo = textView.layoutManager.textLineForIndex(lowerBound - 1),
-                let prevString = textView.textStorage.substring(from: prevLineInfo.range),
-                let lastSelectedString = textView.layoutManager.textLineForIndex(lineIndexes.upperBound)
-            else { return }
+            guard lowerBound > .zero,
+                  let prevLineInfo = textView.layoutManager.textLineForIndex(lowerBound - 1),
+                  let prevString = textView.textStorage.substring(from: prevLineInfo.range),
+                  let lastSelectedString = textView.layoutManager.textLineForIndex(lineIndexes.upperBound) else {
+                return
+            }
 
             textView.insertString(prevString, at: lastSelectedString.range.upperBound)
             textView.replaceCharacters(in: [prevLineInfo.range], with: String())
@@ -48,12 +48,12 @@ extension TextViewController {
             guard let lineIndexes = getOverlappingLines(for: selection.range) else { return }
             let totalLines = textView.layoutManager.lineCount
             let upperBound = lineIndexes.upperBound
-            guard
-                upperBound + 1 < totalLines,
-                let nextLineInfo = textView.layoutManager.textLineForIndex(upperBound + 1),
-                let nextString = textView.textStorage.substring(from: nextLineInfo.range),
-                let firstSelectedString = textView.layoutManager.textLineForIndex(lineIndexes.lowerBound)
-            else { return }
+            guard upperBound + 1 < totalLines,
+                  let nextLineInfo = textView.layoutManager.textLineForIndex(upperBound + 1),
+                  let nextString = textView.textStorage.substring(from: nextLineInfo.range),
+                  let firstSelectedString = textView.layoutManager.textLineForIndex(lineIndexes.lowerBound) else {
+                return
+            }
 
             textView.replaceCharacters(in: [nextLineInfo.range], with: String())
             textView.insertString(nextString, at: firstSelectedString.range.lowerBound)

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+MoveLines.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+MoveLines.swift
@@ -1,0 +1,71 @@
+//
+//  TextViewController+MoveLines.swift
+//  CodeEditSourceEditor
+//
+//  Created by Bogdan Belogurov on 01/06/2025.
+//
+
+import Foundation
+
+extension TextViewController {
+    /// Moves the selected lines up by one line.
+    public func moveLinesUp() {
+        guard !cursorPositions.isEmpty else { return }
+
+        textView.undoManager?.beginUndoGrouping()
+
+        textView.editSelections { textView, selection in
+            guard let lineIndexes = getOverlappingLines(for: selection.range) else { return }
+            let lowerBound = lineIndexes.lowerBound
+            guard
+                lowerBound > .zero,
+                let prevLineInfo = textView.layoutManager.textLineForIndex(lowerBound - 1),
+                let prevString = textView.textStorage.substring(from: prevLineInfo.range),
+                let lastSelectedString = textView.layoutManager.textLineForIndex(lineIndexes.upperBound)
+            else { return }
+
+            textView.insertString(prevString, at: lastSelectedString.range.upperBound)
+            textView.replaceCharacters(in: [prevLineInfo.range], with: String())
+
+            let rangeToSelect = NSRange(
+                start: prevLineInfo.range.lowerBound,
+                end: lastSelectedString.range.location - prevLineInfo.range.length + lastSelectedString.range.length
+            )
+
+            setCursorPositions([CursorPosition(range: rangeToSelect)], scrollToVisible: true)
+        }
+
+        textView.undoManager?.endUndoGrouping()
+    }
+
+    /// Moves the selected lines down by one line.
+    public func moveLinesDown() {
+        guard !cursorPositions.isEmpty else { return }
+
+        textView.undoManager?.beginUndoGrouping()
+
+        textView.editSelections { textView, selection in
+            guard let lineIndexes = getOverlappingLines(for: selection.range) else { return }
+            let totalLines = textView.layoutManager.lineCount
+            let upperBound = lineIndexes.upperBound
+            guard
+                upperBound + 1 < totalLines,
+                let nextLineInfo = textView.layoutManager.textLineForIndex(upperBound + 1),
+                let nextString = textView.textStorage.substring(from: nextLineInfo.range),
+                let firstSelectedString = textView.layoutManager.textLineForIndex(lineIndexes.lowerBound)
+            else { return }
+
+            textView.replaceCharacters(in: [nextLineInfo.range], with: String())
+            textView.insertString(nextString, at: firstSelectedString.range.lowerBound)
+
+            let rangeToSelect = NSRange(
+                start: firstSelectedString.range.location + nextLineInfo.range.length,
+                end: nextLineInfo.range.upperBound
+            )
+
+            setCursorPositions([CursorPosition(range: rangeToSelect)], scrollToVisible: true)
+        }
+
+        textView.undoManager?.endUndoGrouping()
+    }
+}

--- a/Tests/CodeEditSourceEditorTests/Controller/TextViewController+MoveLinesTests.swift
+++ b/Tests/CodeEditSourceEditorTests/Controller/TextViewController+MoveLinesTests.swift
@@ -1,0 +1,107 @@
+//
+//  TextViewController+MoveLinesTests.swift
+//  CodeEditSourceEditor
+//
+//  Created by Bogdan Belogurov on 01/06/2025.
+//
+
+import XCTest
+@testable import CodeEditSourceEditor
+@testable import CodeEditTextView
+import CustomDump
+
+final class TextViewControllerMoveLinesTests: XCTestCase {
+    var controller: TextViewController!
+
+    override func setUpWithError() throws {
+        controller = Mock.textViewController(theme: Mock.theme())
+
+        controller.loadView()
+    }
+
+    func testHandleMoveLinesUpForSingleLine() {
+        let strings: [(NSString, Int)] = [
+            ("This is a test string\n", 0),
+            ("With multiple lines\n", 22)
+        ]
+        for (insertedString, location) in strings {
+            controller.textView.replaceCharacters(
+                in: [NSRange(location: location, length: 0)],
+                with: insertedString as String
+            )
+        }
+
+        let cursorRange = NSRange(location: 40, length: 0)
+        controller.textView.selectionManager.textSelections = [.init(range: cursorRange)]
+        controller.cursorPositions = [CursorPosition(range: cursorRange)]
+
+        controller.moveLinesUp()
+        let expectedString = "With multiple lines\nThis is a test string\n"
+        expectNoDifference(controller.string, expectedString)
+    }
+
+    func testHandleMoveLinesDownForSingleLine() {
+        let strings: [(NSString, Int)] = [
+            ("This is a test string\n", 0),
+            ("With multiple lines\n", 22)
+        ]
+        for (insertedString, location) in strings {
+            controller.textView.replaceCharacters(
+                in: [NSRange(location: location, length: 0)],
+                with: insertedString as String
+            )
+        }
+
+        let cursorRange = NSRange(location: 0, length: 0)
+        controller.textView.selectionManager.textSelections = [.init(range: cursorRange)]
+        controller.cursorPositions = [CursorPosition(range: cursorRange)]
+
+        controller.moveLinesDown()
+        let expectedString = "With multiple lines\nThis is a test string\n"
+        expectNoDifference(controller.string, expectedString)
+    }
+
+    func testHandleMoveLinesUpForMultiLine() {
+        let strings: [(NSString, Int)] = [
+            ("This is a test string\n", 0),
+            ("With multiple lines\n", 22),
+            ("And additional info\n", 42)
+        ]
+        for (insertedString, location) in strings {
+            controller.textView.replaceCharacters(
+                in: [NSRange(location: location, length: 0)],
+                with: insertedString as String
+            )
+        }
+
+        let cursorRange = NSRange(location: 40, length: 15)
+        controller.textView.selectionManager.textSelections = [.init(range: cursorRange)]
+        controller.cursorPositions = [CursorPosition(range: cursorRange)]
+
+        controller.moveLinesUp()
+        let expectedString = "With multiple lines\nAnd additional info\nThis is a test string\n"
+        expectNoDifference(controller.string, expectedString)
+    }
+
+    func testHandleMoveLinesDownForMultiLine() {
+        let strings: [(NSString, Int)] = [
+            ("This is a test string\n", 0),
+            ("With multiple lines\n", 22),
+            ("And additional info\n", 42)
+        ]
+        for (insertedString, location) in strings {
+            controller.textView.replaceCharacters(
+                in: [NSRange(location: location, length: 0)],
+                with: insertedString as String
+            )
+        }
+
+        let cursorRange = NSRange(location: 0, length: 30)
+        controller.textView.selectionManager.textSelections = [.init(range: cursorRange)]
+        controller.cursorPositions = [CursorPosition(range: cursorRange)]
+
+        controller.moveLinesDown()
+        let expectedString = "And additional info\nThis is a test string\nWith multiple lines\n"
+        expectNoDifference(controller.string, expectedString)
+    }
+}


### PR DESCRIPTION
### Description

This PR introduces two new methods to `TextViewController`:
`moveLinesUp()`
`moveLinesDown()`

These methods allow users to move selected lines of text up or down within the text view. 

### Related Issues

* #259 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

I tested a 50k line file to compare performance in Xcode and CodeEdit.
| Xcode | CodeEdit |
|:------:|:---------:|
| <video src="https://github.com/user-attachments/assets/0d56c1a3-fd7b-499b-8ead-26e76f2096ce"> | <video src="https://github.com/user-attachments/assets/0da7c120-37cc-4bc2-b9de-bb1ad71b398f"> |







