### PR TITLE
Use Better Text Storage In Example

### DIFF
--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Documents/CodeEditSourceEditorExampleDocument.swift
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Documents/CodeEditSourceEditorExampleDocument.swift
@@ -33,7 +33,10 @@ struct CodeEditSourceEditorExampleDocument: FileDocument, @unchecked Sendable {
         NSString.stringEncoding(
             for: data,
             encodingOptions: [
-                .allowLossyKey: false, // Fail if using lossy encoding.
+                // Fail if using lossy encoding.
+                .allowLossyKey: false,
+                // In a real app, you'll want to handle more than just this encoding scheme. Check out CodeEdit's
+                // implementation for a more involved solution.
                 .suggestedEncodingsKey: [NSUTF8StringEncoding],
                 .useOnlySuggestedEncodingsKey: true
             ],

--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Documents/CodeEditSourceEditorExampleDocument.swift
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Documents/CodeEditSourceEditorExampleDocument.swift
@@ -8,10 +8,14 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
-struct CodeEditSourceEditorExampleDocument: FileDocument {
-    var text: String
+struct CodeEditSourceEditorExampleDocument: FileDocument, @unchecked Sendable {
+    enum DocumentError: Error {
+        case failedToEncode
+    }
 
-    init(text: String = "") {
+    var text: NSTextStorage
+
+    init(text: NSTextStorage = NSTextStorage(string: "")) {
         self.text = text
     }
 
@@ -25,11 +29,28 @@ struct CodeEditSourceEditorExampleDocument: FileDocument {
         guard let data = configuration.file.regularFileContents else {
             throw CocoaError(.fileReadCorruptFile)
         }
-        text = String(decoding: data, as: UTF8.self)
+        var nsString: NSString?
+        NSString.stringEncoding(
+            for: data,
+            encodingOptions: [
+                .allowLossyKey: false, // Fail if using lossy encoding.
+                .suggestedEncodingsKey: [NSUTF8StringEncoding],
+                .useOnlySuggestedEncodingsKey: true
+            ],
+            convertedString: &nsString,
+            usedLossyConversion: nil
+        )
+        if let nsString {
+            self.text = NSTextStorage(string: nsString as String)
+        } else {
+            fatalError("Failed to read file")
+        }
     }
 
     func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
-        let data = Data(text.utf8)
+        guard let data = (text.string as NSString?)?.data(using: NSUTF8StringEncoding) else {
+            throw DocumentError.failedToEncode
+        }
         return .init(regularFileWithContents: data)
     }
 }

--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/ContentView.swift
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/ContentView.swift
@@ -39,7 +39,7 @@ struct ContentView: View {
     var body: some View {
         GeometryReader { proxy in
             CodeEditSourceEditor(
-                $document.text,
+                document.text,
                 language: language,
                 theme: theme,
                 font: font,

--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/StatusBar.swift
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/StatusBar.swift
@@ -30,7 +30,7 @@ struct StatusBar: View {
     var body: some View {
         HStack {
             Menu {
-                IndentPicker(indentOption: $indentOption, enabled: document.text.isEmpty)
+                IndentPicker(indentOption: $indentOption, enabled: document.text.length == 0)
                     .buttonStyle(.borderless)
                 Toggle("Wrap Lines", isOn: $wrapLines)
                 Toggle("Show Minimap", isOn: $showMinimap)
@@ -106,8 +106,8 @@ struct StatusBar: View {
         guard let fileURL else { return nil  }
         return CodeLanguage.detectLanguageFrom(
             url: fileURL,
-            prefixBuffer: document.text.getFirstLines(5),
-            suffixBuffer: document.text.getLastLines(5)
+            prefixBuffer: document.text.string.getFirstLines(5),
+            suffixBuffer: document.text.string.getLastLines(5)
         )
     }
 


### PR DESCRIPTION
### Description

Updates the example app to use an NSTextStorage object instead of a plain String for the editor's contents. This should help with debugging for CodeEdit, to help compare apples to apples performance-wise. For editing anything non-trivial, `String` causes SwiftUI to perform a character-by-character comparison on the string to check if the view needs invalidating.

### Related Issues

N/A

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

