### PR TITLE
Added Select Next/Previous Occurrence commands

### DIFF
--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
@@ -201,6 +201,8 @@ extension TextViewController {
 
     func handleCommand(event: NSEvent, modifierFlags: UInt) -> NSEvent? {
         let commandKey = NSEvent.ModifierFlags.command.rawValue
+        let optionKey = NSEvent.ModifierFlags.option.rawValue
+        let shiftKey = NSEvent.ModifierFlags.shift.rawValue
 
         switch (modifierFlags, event.charactersIgnoringModifiers) {
         case (commandKey, "/"):
@@ -218,6 +220,12 @@ extension TextViewController {
             return nil
         case (0, "\u{1b}"): // Escape key
             self.findViewController?.hideFindPanel()
+            return nil
+        case (commandKey | optionKey | shiftKey, "E"): // ⇧ ⌥ ⌘ E - uppercase letter because shiftKey is present
+            selectPreviousOccurrence(nil)
+            return nil
+        case (commandKey | optionKey, "e"): // ⌥ ⌘ E
+            selectNextOccurrence(nil)
             return nil
         case (_, _):
             return event

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -21,6 +21,9 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
     public static let cursorPositionUpdatedNotification: Notification.Name = .init("TextViewController.cursorPositionNotification")
 
     weak var findViewController: FindViewController?
+    var findPanelViewModel: FindPanelViewModel? {
+        findViewController?.viewModel
+    }
 
     var scrollView: NSScrollView!
     var textView: TextView!
@@ -391,4 +394,51 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
         }
         localEvenMonitor = nil
     }
+
+    // MARK: - Multiple Selection Commands
+
+    @objc func selectNextOccurrence(_ sender: Any?) {
+        guard let findPanelViewModel = findPanelViewModel else { return }
+        findPanelViewModel.selectNextOccurrence()
+    }
+
+    @objc func selectPreviousOccurrence(_ sender: Any?) {
+        guard let findPanelViewModel = findPanelViewModel else { return }
+        findPanelViewModel.selectPreviousOccurrence()
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Initialize find view controller if not already set
+        if findViewController == nil {
+            let findVC = FindViewController(target: self, childView: view)
+            addChild(findVC)
+            view.addSubview(findVC.view)
+
+            // Set up constraints
+            findVC.view.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                findVC.view.topAnchor.constraint(equalTo: view.topAnchor),
+                findVC.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                findVC.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            ])
+
+            findViewController = findVC
+        }
+    }
 }
+
+// MARK: - NSMenuItemValidation
+
+extension TextViewController: NSMenuItemValidation {
+    public func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        switch menuItem.action {
+        case #selector(selectNextOccurrence(_:)), #selector(selectPreviousOccurrence(_:)):
+            return textView.selectedRange.length > 0
+        default:
+            return true
+        }
+    }
+}
+

--- a/Sources/CodeEditSourceEditor/Find/ViewModel/FindPanelViewModel+Emphasis.swift
+++ b/Sources/CodeEditSourceEditor/Find/ViewModel/FindPanelViewModel+Emphasis.swift
@@ -8,7 +8,7 @@
 import CodeEditTextView
 
 extension FindPanelViewModel {
-    func addMatchEmphases(flashCurrent: Bool) {
+    func addMatchEmphases(flashCurrent: Bool, allowSelection: Bool = true) {
         guard let target = target, let emphasisManager = target.textView.emphasisManager else {
             return
         }
@@ -23,7 +23,7 @@ extension FindPanelViewModel {
                 style: .standard,
                 flash: flashCurrent && index == currentFindMatchIndex,
                 inactive: index != currentFindMatchIndex,
-                selectInDocument: index == currentFindMatchIndex
+                selectInDocument: allowSelection && index == currentFindMatchIndex
             )
         }
 
@@ -31,7 +31,7 @@ extension FindPanelViewModel {
         emphasisManager.addEmphases(emphases, for: EmphasisGroup.find)
     }
 
-    func flashCurrentMatch() {
+    func flashCurrentMatch(allowSelection: Bool = true) {
         guard let target = target,
               let emphasisManager = target.textView.emphasisManager,
               let currentFindMatchIndex else {
@@ -50,7 +50,7 @@ extension FindPanelViewModel {
                 style: .standard,
                 flash: true,
                 inactive: false,
-                selectInDocument: true
+                selectInDocument: allowSelection
             )
         )
 

--- a/Tests/CodeEditSourceEditorTests/FindPanelTests.swift
+++ b/Tests/CodeEditSourceEditorTests/FindPanelTests.swift
@@ -236,4 +236,65 @@ struct FindPanelTests {
         viewModel.find()
         #expect(viewModel.findMatches.count == 3)
     }
+
+    @Test func selectNextOccurrence() async throws {
+        target.textView.string = "test1 test2 test3"
+        
+        // Select first occurrence
+        target.setCursorPositions([CursorPosition(range: NSRange(location: 0, length: 4))], scrollToVisible: false)
+        
+        // Select next occurrence
+        viewModel.selectNextOccurrence()
+        
+        // Verify we have two selections
+        #expect(target.cursorPositions.count == 2)
+        #expect(target.cursorPositions[0].range == NSRange(location: 0, length: 4))
+        #expect(target.cursorPositions[1].range == NSRange(location: 6, length: 4))
+    }
+
+    @Test func selectPreviousOccurrence() async throws {
+        target.textView.string = "test1 test2 test3"
+        
+        // Select last occurrence
+        target.setCursorPositions([CursorPosition(range: NSRange(location: 12, length: 4))], scrollToVisible: false)
+        
+        // Select previous occurrence
+        viewModel.selectPreviousOccurrence()
+        
+        // Verify we have two selections
+        #expect(target.cursorPositions.count == 2)
+        #expect(target.cursorPositions[0].range == NSRange(location: 12, length: 4))
+        #expect(target.cursorPositions[1].range == NSRange(location: 6, length: 4))
+    }
+
+    @Test func selectNextOccurrenceWrapsAround() async throws {
+        target.textView.string = "test1 test2 test3"
+        
+        // Select last occurrence
+        target.setCursorPositions([CursorPosition(range: NSRange(location: 12, length: 4))], scrollToVisible: false)
+        
+        // Select next occurrence (should wrap to first)
+        viewModel.selectNextOccurrence()
+        
+        // Verify we have two selections
+        #expect(target.cursorPositions.count == 2)
+        #expect(target.cursorPositions[0].range == NSRange(location: 12, length: 4))
+        #expect(target.cursorPositions[1].range == NSRange(location: 0, length: 4))
+    }
+
+    @Test func selectPreviousOccurrenceWrapsAround() async throws {
+        target.textView.string = "test1 test2 test3"
+        
+        // Select first occurrence
+        target.setCursorPositions([CursorPosition(range: NSRange(location: 0, length: 4))], scrollToVisible: false)
+        
+        // Select previous occurrence (should wrap to last)
+        viewModel.selectPreviousOccurrence()
+        
+        // Verify we have two selections
+        #expect(target.cursorPositions.count == 2)
+        #expect(target.cursorPositions[0].range == NSRange(location: 0, length: 4))
+        #expect(target.cursorPositions[1].range == NSRange(location: 12, length: 4))
+    }
 }
+ 


### PR DESCRIPTION
### Description

Adds Select Next Occurrence (⇧⌥⌘E) and Select Previous Occurrence (⇧⌥…⌘E) commands.

Respects Wrap Around and Match Case settings in the Find panel.

### Related Issues

* closes #300

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/user-attachments/assets/9774b175-1972-44bf-8a74-4ee2e2bace92
