### PR TITLE
Remove the use of NSEvent for lines movement API

### DIFF
--- a/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController+LoadView.swift
@@ -201,7 +201,6 @@ extension TextViewController {
 
     func handleCommand(event: NSEvent, modifierFlags: UInt) -> NSEvent? {
         let commandKey = NSEvent.ModifierFlags.command.rawValue
-        let commandOptionKey = NSEvent.ModifierFlags.command.union(.option).rawValue
 
         switch (modifierFlags, event.charactersIgnoringModifiers) {
         case (commandKey, "/"):
@@ -210,14 +209,8 @@ extension TextViewController {
         case (commandKey, "["):
             handleIndent(inwards: true)
             return nil
-        case (commandOptionKey, "["):
-            moveLinesUp()
-            return nil
         case (commandKey, "]"):
             handleIndent()
-            return nil
-        case (commandOptionKey, "]"):
-            moveLinesDown()
             return nil
         case (commandKey, "f"):
             _ = self.textView.resignFirstResponder()


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Remove the use of NSEvent for the lines movement API, we need to interact through the editor menu.

### Related Issues

* #259 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code


### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->

https://github.com/user-attachments/assets/1e5c1dd9-3b54-4fbb-87d0-020df3efe684


