### PR TITLE
Draw Invisible Characters

### DIFF
--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "69282e2ea7ad8976b062b945d575da47b61ed208",
-        "version" : "0.11.1"
+        "revision" : "c045ffcf4d8b2904e7bd138cdeccda99cba3ab3c",
+        "version" : "0.11.2"
       }
     },
     {

--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/ContentView.swift
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/ContentView.swift
@@ -30,6 +30,7 @@ struct ContentView: View {
     @State private var indentOption: IndentOption = .spaces(count: 4)
     @AppStorage("reformatAtColumn") private var reformatAtColumn: Int = 80
     @AppStorage("showReformattingGuide") private var showReformattingGuide: Bool = false
+    @State private var invisibleCharactersConfig: InvisibleCharactersConfig = .empty
 
     init(document: Binding<CodeEditSourceEditorExampleDocument>, fileURL: URL?) {
         self._document = document
@@ -56,7 +57,8 @@ struct ContentView: View {
                 useSystemCursor: useSystemCursor,
                 showMinimap: showMinimap,
                 reformatAtColumn: reformatAtColumn,
-                showReformattingGuide: showReformattingGuide
+                showReformattingGuide: showReformattingGuide,
+                invisibleCharactersConfig: invisibleCharactersConfig
             )
             .overlay(alignment: .bottom) {
                 StatusBar(
@@ -71,7 +73,8 @@ struct ContentView: View {
                     showMinimap: $showMinimap,
                     indentOption: $indentOption,
                     reformatAtColumn: $reformatAtColumn,
-                    showReformattingGuide: $showReformattingGuide
+                    showReformattingGuide: $showReformattingGuide,
+                    invisibles: $invisibleCharactersConfig
                 )
             }
             .ignoresSafeArea()

--- a/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/StatusBar.swift
+++ b/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Views/StatusBar.swift
@@ -26,6 +26,7 @@ struct StatusBar: View {
     @Binding var indentOption: IndentOption
     @Binding var reformatAtColumn: Int
     @Binding var showReformattingGuide: Bool
+    @Binding var invisibles: InvisibleCharactersConfig
 
     var body: some View {
         HStack {
@@ -49,6 +50,33 @@ struct StatusBar: View {
                     Toggle("Use System Cursor", isOn: $useSystemCursor)
                         .disabled(true)
                         .help("macOS 14 required")
+                }
+
+                Menu {
+                    Toggle("Spaces", isOn: $invisibles.showSpaces)
+                    Toggle("Tabs", isOn: $invisibles.showTabs)
+                    Toggle("Line Endings", isOn: $invisibles.showLineEndings)
+                    Divider()
+                    Toggle(
+                        "Warning Characters",
+                        isOn: Binding(
+                            get: {
+                                !invisibles.warningCharacters.isEmpty
+                            },
+                            set: { newValue in
+                                // In this example app, we only add one character
+                                // For real apps, consider providing a table where users can add UTF16
+                                // char codes to warn about, as well as a set of good defaults.
+                                if newValue {
+                                    invisibles.warningCharacters.insert(0x200B) // zero-width space
+                                } else {
+                                    invisibles.warningCharacters.removeAll()
+                                }
+                            }
+                        )
+                    )
+                } label: {
+                    Text("Invisibles")
                 }
             } label: {}
                 .background {

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "69282e2ea7ad8976b062b945d575da47b61ed208",
-        "version" : "0.11.1"
+        "revision" : "c045ffcf4d8b2904e7bd138cdeccda99cba3ab3c",
+        "version" : "0.11.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditLanguages.git",
       "state" : {
-        "revision" : "331d5dbc5fc8513be5848fce8a2a312908f36a11",
-        "version" : "0.1.20"
+        "revision" : "32a1ddcb44d0bcf9bdb41ae426fa1bb7198e62fe",
+        "version" : "0.1.21"
       }
     },
     {
@@ -16,15 +16,6 @@
       "state" : {
         "revision" : "ae69712b08571c4469c2ed5cd38ad9f19439793e",
         "version" : "0.2.3"
-      }
-    },
-    {
-      "identity" : "codeedittextview",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
-      "state" : {
-        "revision" : "69282e2ea7ad8976b062b945d575da47b61ed208",
-        "version" : "0.11.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditLanguages.git",
       "state" : {
-        "revision" : "32a1ddcb44d0bcf9bdb41ae426fa1bb7198e62fe",
-        "version" : "0.1.21"
+        "revision" : "331d5dbc5fc8513be5848fce8a2a312908f36a11",
+        "version" : "0.1.20"
       }
     },
     {
@@ -16,6 +16,15 @@
       "state" : {
         "revision" : "ae69712b08571c4469c2ed5cd38ad9f19439793e",
         "version" : "0.2.3"
+      }
+    },
+    {
+      "identity" : "codeedittextview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
+      "state" : {
+        "revision" : "69282e2ea7ad8976b062b945d575da47b61ed208",
+        "version" : "0.11.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         // A fast, efficient, text view for code.
         .package(
             url: "https://github.com/CodeEditApp/CodeEditTextView.git",
-            from: "0.11.1"
+            from: "0.11.2"
         ),
         // tree-sitter languages
         .package(

--- a/Sources/CodeEditSourceEditor/CodeEditSourceEditor/CodeEditSourceEditor.swift
+++ b/Sources/CodeEditSourceEditor/CodeEditSourceEditor/CodeEditSourceEditor.swift
@@ -50,10 +50,14 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
     ///   - useSystemCursor: If true, uses the system cursor on `>=macOS 14`.
     ///   - undoManager: The undo manager for the text view. Defaults to `nil`, which will create a new CEUndoManager
     ///   - coordinators: Any text coordinators for the view to use. See ``TextViewCoordinator`` for more information.
-    ///   - showMinimap: Whether to show the minimap
-    ///   - reformatAtColumn: The column to reformat at
-    ///   - showReformattingGuide: Whether to show the reformatting guide
+    ///   - showMinimap: Whether to show the minimap.
+    ///   - reformatAtColumn: The column to reformat at.
+    ///   - showReformattingGuide: Whether to show the reformatting guide.
     ///   - invisibleCharactersConfig: Configuration for displaying invisible characters. Defaults to an empty object.
+    ///                                See ``TextViewController/invisibleCharactersConfig`` and
+    ///                                ``InvisibleCharactersConfig`` for more information.
+    ///   - warningCharacters: A set of characters the editor should draw with a small red border. See
+    ///                        ``TextViewController/warningCharacters`` for more information.
     public init(
         _ text: Binding<String>,
         language: CodeLanguage,
@@ -79,7 +83,8 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         showMinimap: Bool,
         reformatAtColumn: Int,
         showReformattingGuide: Bool,
-        invisibleCharactersConfig: InvisibleCharactersConfig = .empty
+        invisibleCharactersConfig: InvisibleCharactersConfig = .empty,
+        warningCharacters: Set<UInt16> = []
     ) {
         self.text = .binding(text)
         self.language = language
@@ -110,6 +115,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         self.reformatAtColumn = reformatAtColumn
         self.showReformattingGuide = showReformattingGuide
         self.invisibleCharactersConfig = invisibleCharactersConfig
+        self.warningCharacters = warningCharacters
     }
 
     /// Initializes a Text Editor
@@ -139,10 +145,14 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
     ///                           See `BracketPairEmphasis` for more information. Defaults to `nil`
     ///   - undoManager: The undo manager for the text view. Defaults to `nil`, which will create a new CEUndoManager
     ///   - coordinators: Any text coordinators for the view to use. See ``TextViewCoordinator`` for more information.
-    ///   - showMinimap: Whether to show the minimap
-    ///   - reformatAtColumn: The column to reformat at
-    ///   - showReformattingGuide: Whether to show the reformatting guide
+    ///   - showMinimap: Whether to show the minimap.
+    ///   - reformatAtColumn: The column to reformat at.
+    ///   - showReformattingGuide: Whether to show the reformatting guide.
     ///   - invisibleCharactersConfig: Configuration for displaying invisible characters. Defaults to an empty object.
+    ///                                See ``TextViewController/invisibleCharactersConfig`` and
+    ///                                ``InvisibleCharactersConfig`` for more information.
+    ///   - warningCharacters: A set of characters the editor should draw with a small red border. See
+    ///                        ``TextViewController/warningCharacters`` for more information.
     public init(
         _ text: NSTextStorage,
         language: CodeLanguage,
@@ -168,7 +178,8 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         showMinimap: Bool,
         reformatAtColumn: Int,
         showReformattingGuide: Bool,
-        invisibleCharactersConfig: InvisibleCharactersConfig = .empty
+        invisibleCharactersConfig: InvisibleCharactersConfig = .empty,
+        warningCharacters: Set<UInt16> = []
     ) {
         self.text = .storage(text)
         self.language = language
@@ -199,6 +210,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         self.reformatAtColumn = reformatAtColumn
         self.showReformattingGuide = showReformattingGuide
         self.invisibleCharactersConfig = invisibleCharactersConfig
+        self.warningCharacters = warningCharacters
     }
 
     package var text: TextAPI
@@ -226,6 +238,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
     private var reformatAtColumn: Int
     private var showReformattingGuide: Bool
     private var invisibleCharactersConfig: InvisibleCharactersConfig
+    private var warningCharacters: Set<UInt16>
 
     public typealias NSViewControllerType = TextViewController
 
@@ -364,6 +377,10 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         if controller.invisibleCharactersConfig != invisibleCharactersConfig {
             controller.invisibleCharactersConfig = invisibleCharactersConfig
         }
+
+        if controller.warningCharacters != warningCharacters {
+            controller.warningCharacters = warningCharacters
+        }
     }
 
     private func updateThemeAndLanguage(_ controller: TextViewController) {
@@ -410,6 +427,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         controller.reformatAtColumn == reformatAtColumn &&
         controller.showReformattingGuide == showReformattingGuide &&
         controller.invisibleCharactersConfig == invisibleCharactersConfig &&
+        controller.warningCharacters == warningCharacters &&
         areHighlightProvidersEqual(controller: controller, coordinator: coordinator)
     }
 

--- a/Sources/CodeEditSourceEditor/CodeEditSourceEditor/CodeEditSourceEditor.swift
+++ b/Sources/CodeEditSourceEditor/CodeEditSourceEditor/CodeEditSourceEditor.swift
@@ -53,7 +53,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
     ///   - showMinimap: Whether to show the minimap
     ///   - reformatAtColumn: The column to reformat at
     ///   - showReformattingGuide: Whether to show the reformatting guide
-    ///   - invisibleCharactersConfig: Configuration for displaying invisible characters. Defaults to an empty object.   
+    ///   - invisibleCharactersConfig: Configuration for displaying invisible characters. Defaults to an empty object.
     public init(
         _ text: Binding<String>,
         language: CodeLanguage,

--- a/Sources/CodeEditSourceEditor/CodeEditSourceEditor/CodeEditSourceEditor.swift
+++ b/Sources/CodeEditSourceEditor/CodeEditSourceEditor/CodeEditSourceEditor.swift
@@ -53,6 +53,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
     ///   - showMinimap: Whether to show the minimap
     ///   - reformatAtColumn: The column to reformat at
     ///   - showReformattingGuide: Whether to show the reformatting guide
+    ///   - invisibleCharactersConfig: Configuration for displaying invisible characters. Defaults to an empty object.   
     public init(
         _ text: Binding<String>,
         language: CodeLanguage,
@@ -77,7 +78,8 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         coordinators: [any TextViewCoordinator] = [],
         showMinimap: Bool,
         reformatAtColumn: Int,
-        showReformattingGuide: Bool
+        showReformattingGuide: Bool,
+        invisibleCharactersConfig: InvisibleCharactersConfig = .empty
     ) {
         self.text = .binding(text)
         self.language = language
@@ -107,6 +109,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         self.showMinimap = showMinimap
         self.reformatAtColumn = reformatAtColumn
         self.showReformattingGuide = showReformattingGuide
+        self.invisibleCharactersConfig = invisibleCharactersConfig
     }
 
     /// Initializes a Text Editor
@@ -139,6 +142,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
     ///   - showMinimap: Whether to show the minimap
     ///   - reformatAtColumn: The column to reformat at
     ///   - showReformattingGuide: Whether to show the reformatting guide
+    ///   - invisibleCharactersConfig: Configuration for displaying invisible characters. Defaults to an empty object.
     public init(
         _ text: NSTextStorage,
         language: CodeLanguage,
@@ -163,7 +167,8 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         coordinators: [any TextViewCoordinator] = [],
         showMinimap: Bool,
         reformatAtColumn: Int,
-        showReformattingGuide: Bool
+        showReformattingGuide: Bool,
+        invisibleCharactersConfig: InvisibleCharactersConfig = .empty
     ) {
         self.text = .storage(text)
         self.language = language
@@ -193,6 +198,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         self.showMinimap = showMinimap
         self.reformatAtColumn = reformatAtColumn
         self.showReformattingGuide = showReformattingGuide
+        self.invisibleCharactersConfig = invisibleCharactersConfig
     }
 
     package var text: TextAPI
@@ -219,6 +225,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
     package var showMinimap: Bool
     private var reformatAtColumn: Int
     private var showReformattingGuide: Bool
+    private var invisibleCharactersConfig: InvisibleCharactersConfig
 
     public typealias NSViewControllerType = TextViewController
 
@@ -247,7 +254,8 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
             coordinators: coordinators,
             showMinimap: showMinimap,
             reformatAtColumn: reformatAtColumn,
-            showReformattingGuide: showReformattingGuide
+            showReformattingGuide: showReformattingGuide,
+            invisibleCharactersConfig: invisibleCharactersConfig
         )
         switch text {
         case .binding(let binding):
@@ -352,6 +360,10 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         if controller.useSystemCursor != useSystemCursor {
             controller.useSystemCursor = useSystemCursor
         }
+
+        if controller.invisibleCharactersConfig != invisibleCharactersConfig {
+            controller.invisibleCharactersConfig = invisibleCharactersConfig
+        }
     }
 
     private func updateThemeAndLanguage(_ controller: TextViewController) {
@@ -397,6 +409,7 @@ public struct CodeEditSourceEditor: NSViewControllerRepresentable {
         controller.showMinimap == showMinimap &&
         controller.reformatAtColumn == reformatAtColumn &&
         controller.showReformattingGuide == showReformattingGuide &&
+        controller.invisibleCharactersConfig == invisibleCharactersConfig &&
         areHighlightProvidersEqual(controller: controller, coordinator: coordinator)
     }
 

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -27,6 +27,15 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
     var gutterView: GutterView!
     var minimapView: MinimapView!
 
+    /// The reformatting guide view
+    var guideView: ReformattingGuideView! {
+        didSet {
+            if let oldValue = oldValue {
+                oldValue.removeFromSuperview()
+            }
+        }
+    }
+
     var minimapXConstraint: NSLayoutConstraint?
 
     var _undoManager: CEUndoManager!
@@ -263,24 +272,28 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
         }
     }
 
-    /// The reformatting guide view
-    var guideView: ReformattingGuideView! {
-        didSet {
-            if let oldValue = oldValue {
-                oldValue.removeFromSuperview()
-            }
-        }
-    }
-
     /// Configuration for drawing invisible characters.
     ///
     /// See ``InvisibleCharactersConfig`` for more details.
-    var invisibleCharactersConfig: InvisibleCharactersConfig {
+    public var invisibleCharactersConfig: InvisibleCharactersConfig {
         get {
             invisibleCharactersCoordinator.config
         }
         set {
             invisibleCharactersCoordinator.config = newValue
+        }
+    }
+
+    /// A set of characters the editor should draw with a small red border.
+    ///
+    /// Indicates characters that the user may not have meant to insert, such as a zero-width space: `(0x200D)` or a
+    /// non-standard quote character: `“ (0x201C)`.
+    public var warningCharacters: Set<UInt16> {
+        get {
+            invisibleCharactersCoordinator.warningCharacters
+        }
+        set {
+            invisibleCharactersCoordinator.warningCharacters = newValue
         }
     }
 
@@ -314,7 +327,8 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
         showMinimap: Bool,
         reformatAtColumn: Int = 80,
         showReformattingGuide: Bool = false,
-        invisibleCharactersConfig: InvisibleCharactersConfig = .empty
+        invisibleCharactersConfig: InvisibleCharactersConfig = .empty,
+        warningCharacters: Set<UInt16> = []
     ) {
         self.language = language
         self.font = font
@@ -339,6 +353,7 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
         self.showReformattingGuide = showReformattingGuide
         self.invisibleCharactersCoordinator = InvisibleCharactersCoordinator(
             config: invisibleCharactersConfig,
+            warningCharacters: warningCharacters,
             indentOption: indentOption,
             theme: theme,
             font: font

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -331,21 +331,16 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
         self.showMinimap = showMinimap
         self.reformatAtColumn = reformatAtColumn
         self.showReformattingGuide = showReformattingGuide
-        self.invisibleCharactersCoordinator = InvisibleCharactersCoordinator(
-            config: invisibleCharactersConfig,
-            indentOption: indentOption,
-            theme: theme,
-            font: font
-        )
+
+        invisibleCharactersCoordinator = .init(config: .empty, indentOption: indentOption, theme: theme, font: font)
         self.invisibleCharactersConfig = invisibleCharactersConfig
 
         super.init(nibName: nil, bundle: nil)
 
-        let platformGuardedSystemCursor: Bool
-        if #available(macOS 14, *) {
-            platformGuardedSystemCursor = useSystemCursor
+        let platformGuardedSystemCursor: Bool = if #available(macOS 14, *) {
+            useSystemCursor
         } else {
-            platformGuardedSystemCursor = false
+            false
         }
 
         if let idx = highlightProviders.firstIndex(where: { $0 is TreeSitterClient }),
@@ -417,4 +412,4 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
         }
         localEvenMonitor = nil
     }
-}
+} // swiftlint:disable:this file_length

--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -276,14 +276,20 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
     ///
     /// See ``InvisibleCharactersConfig`` for more details.
     var invisibleCharactersConfig: InvisibleCharactersConfig {
-        didSet {
-            invisibleCharactersCoordinator.config = invisibleCharactersConfig
+        get {
+            invisibleCharactersCoordinator.config
+        }
+        set {
+            invisibleCharactersCoordinator.config = newValue
         }
     }
 
     // MARK: Init
 
-    init(
+    // Disabling function body length warning for now. There's an open issue for combining a lot of these parameters
+    // into a single config object.
+
+    init( // swiftlint:disable:this function_body_length
         string: String,
         language: CodeLanguage,
         font: NSFont,
@@ -331,9 +337,12 @@ public class TextViewController: NSViewController { // swiftlint:disable:this ty
         self.showMinimap = showMinimap
         self.reformatAtColumn = reformatAtColumn
         self.showReformattingGuide = showReformattingGuide
-
-        invisibleCharactersCoordinator = .init(config: .empty, indentOption: indentOption, theme: theme, font: font)
-        self.invisibleCharactersConfig = invisibleCharactersConfig
+        self.invisibleCharactersCoordinator = InvisibleCharactersCoordinator(
+            config: invisibleCharactersConfig,
+            indentOption: indentOption,
+            theme: theme,
+            font: font
+        )
 
         super.init(nibName: nil, bundle: nil)
 

--- a/Sources/CodeEditSourceEditor/InvisibleCharacters/InvisibleCharactersConfig.swift
+++ b/Sources/CodeEditSourceEditor/InvisibleCharacters/InvisibleCharactersConfig.swift
@@ -12,7 +12,7 @@
 public struct InvisibleCharactersConfig: Equatable, Hashable, Sendable, Codable {
     /// An empty configuration.
     public static var empty: InvisibleCharactersConfig {
-        InvisibleCharactersConfig(showSpaces: false, showTabs: false, showLineEndings: false, warningCharacters: [])
+        InvisibleCharactersConfig(showSpaces: false, showTabs: false, showLineEndings: false)
     }
 
     /// Set to true to draw spaces with a dot.
@@ -37,22 +37,10 @@ public struct InvisibleCharactersConfig: Equatable, Hashable, Sendable, Codable 
     /// Replacement when drawing the line separator character, enabled by ``showLineEndings``.
     public var lineSeparatorReplacement: String = "⏎"
 
-    /// A set of characters the editor should draw with a small red border.
-    ///
-    /// Indicates characters that the user may not have meant to insert, such as a zero-width space: `(0x200D)` or a
-    /// non-standard quote character: `“ (0x201C)`.
-    public var warningCharacters: Set<UInt16>
-
-    public init(
-        showSpaces: Bool,
-        showTabs: Bool,
-        showLineEndings: Bool,
-        warningCharacters: Set<UInt16>
-    ) {
+    public init(showSpaces: Bool, showTabs: Bool, showLineEndings: Bool) {
         self.showSpaces = showSpaces
         self.showTabs = showTabs
         self.showLineEndings = showLineEndings
-        self.warningCharacters = warningCharacters
     }
 
     /// Determines what characters should trigger a custom drawing action.
@@ -73,8 +61,6 @@ public struct InvisibleCharactersConfig: Equatable, Hashable, Sendable, Codable 
             set.insert(Symbols.paragraphSeparator)
             set.insert(Symbols.lineSeparator)
         }
-
-        set.formUnion(warningCharacters)
 
         return set
     }

--- a/Sources/CodeEditSourceEditor/InvisibleCharacters/InvisibleCharactersConfig.swift
+++ b/Sources/CodeEditSourceEditor/InvisibleCharacters/InvisibleCharactersConfig.swift
@@ -1,0 +1,63 @@
+//
+//  InvisibleCharactersConfig.swift
+//  CodeEditSourceEditor
+//
+//  Created by Khan Winter on 6/11/25.
+//
+
+/// Configuration for how the editor draws invisible characters.
+public struct InvisibleCharactersConfig: Equatable, Hashable, Sendable, Codable {
+    /// An empty configuration.
+    public static var empty: InvisibleCharactersConfig {
+        InvisibleCharactersConfig(showSpaces: false, showTabs: false, showLineEndings: false, warningCharacters: [])
+    }
+
+    /// Set to true to draw spaces with a dot.
+    public var showSpaces: Bool
+    /// Set to true to draw tabs with a small arrow.
+    public var showTabs: Bool
+    /// Set to true to draw line endings.
+    public var showLineEndings: Bool
+    /// A set of characters the editor should draw with a small red border.
+    ///
+    /// Indicates characters that the user may not have meant to insert, such as a zero-width space: `(0x200D)` or a
+    /// non-standard quote character: `“ (0x201C)`.
+    public var warningCharacters: Set<UInt16>
+
+    public init(showSpaces: Bool, showTabs: Bool, showLineEndings: Bool, warningCharacters: Set<UInt16>) {
+        self.showSpaces = showSpaces
+        self.showTabs = showTabs
+        self.showLineEndings = showLineEndings
+        self.warningCharacters = warningCharacters
+    }
+    
+    /// Determines what characters should trigger a custom drawing action.
+    func triggerCharacters() -> Set<UInt16> {
+        var set = Set<UInt16>()
+
+        if showSpaces {
+            set.insert(Symbols.space)
+        }
+
+        if showTabs {
+            set.insert(Symbols.tab)
+        }
+
+        if showLineEndings {
+            set.insert(Symbols.lineFeed)
+            set.insert(Symbols.carriageReturn)
+        }
+
+        set.formUnion(warningCharacters)
+
+        return set
+    }
+    
+    /// Some commonly used whitespace symbols in their unichar representation.
+    public enum Symbols {
+        public static let space: UInt16 = 0x20
+        public static let tab: UInt16 = 0x9
+        public static let lineFeed: UInt16 = 0xA // \n
+        public static let carriageReturn: UInt16 = 0xD // \r
+    }
+}

--- a/Sources/CodeEditSourceEditor/InvisibleCharacters/InvisibleCharactersConfig.swift
+++ b/Sources/CodeEditSourceEditor/InvisibleCharacters/InvisibleCharactersConfig.swift
@@ -30,7 +30,7 @@ public struct InvisibleCharactersConfig: Equatable, Hashable, Sendable, Codable 
         self.showLineEndings = showLineEndings
         self.warningCharacters = warningCharacters
     }
-    
+
     /// Determines what characters should trigger a custom drawing action.
     func triggerCharacters() -> Set<UInt16> {
         var set = Set<UInt16>()
@@ -52,7 +52,7 @@ public struct InvisibleCharactersConfig: Equatable, Hashable, Sendable, Codable 
 
         return set
     }
-    
+
     /// Some commonly used whitespace symbols in their unichar representation.
     public enum Symbols {
         public static let space: UInt16 = 0x20

--- a/Sources/CodeEditSourceEditor/InvisibleCharacters/InvisibleCharactersConfig.swift
+++ b/Sources/CodeEditSourceEditor/InvisibleCharacters/InvisibleCharactersConfig.swift
@@ -6,6 +6,9 @@
 //
 
 /// Configuration for how the editor draws invisible characters.
+///
+/// Enable specific categories using the ``showSpaces``, ``showTabs``, and ``showLineEndings`` toggles. Customize
+/// drawing further with the ``spaceReplacement`` and family variables.
 public struct InvisibleCharactersConfig: Equatable, Hashable, Sendable, Codable {
     /// An empty configuration.
     public static var empty: InvisibleCharactersConfig {
@@ -14,17 +17,38 @@ public struct InvisibleCharactersConfig: Equatable, Hashable, Sendable, Codable 
 
     /// Set to true to draw spaces with a dot.
     public var showSpaces: Bool
+
     /// Set to true to draw tabs with a small arrow.
     public var showTabs: Bool
+
     /// Set to true to draw line endings.
     public var showLineEndings: Bool
+
+    /// Replacement when drawing the space character, enabled by ``showSpaces``.
+    public var spaceReplacement: String = "·"
+    /// Replacement when drawing the tab character, enabled by ``showTabs``.
+    public var tabReplacement: String = "→"
+    /// Replacement when drawing the carriage return character, enabled by ``showLineEndings``.
+    public var carriageReturnReplacement: String = "↵"
+    /// Replacement when drawing the line feed character, enabled by ``showLineEndings``.
+    public var lineFeedReplacement: String = "¬"
+    /// Replacement when drawing the paragraph separator character, enabled by ``showLineEndings``.
+    public var paragraphSeparatorReplacement: String = "¶"
+    /// Replacement when drawing the line separator character, enabled by ``showLineEndings``.
+    public var lineSeparatorReplacement: String = "⏎"
+
     /// A set of characters the editor should draw with a small red border.
     ///
     /// Indicates characters that the user may not have meant to insert, such as a zero-width space: `(0x200D)` or a
     /// non-standard quote character: `“ (0x201C)`.
     public var warningCharacters: Set<UInt16>
 
-    public init(showSpaces: Bool, showTabs: Bool, showLineEndings: Bool, warningCharacters: Set<UInt16>) {
+    public init(
+        showSpaces: Bool,
+        showTabs: Bool,
+        showLineEndings: Bool,
+        warningCharacters: Set<UInt16>
+    ) {
         self.showSpaces = showSpaces
         self.showTabs = showTabs
         self.showLineEndings = showLineEndings
@@ -46,6 +70,8 @@ public struct InvisibleCharactersConfig: Equatable, Hashable, Sendable, Codable 
         if showLineEndings {
             set.insert(Symbols.lineFeed)
             set.insert(Symbols.carriageReturn)
+            set.insert(Symbols.paragraphSeparator)
+            set.insert(Symbols.lineSeparator)
         }
 
         set.formUnion(warningCharacters)
@@ -59,5 +85,7 @@ public struct InvisibleCharactersConfig: Equatable, Hashable, Sendable, Codable 
         public static let tab: UInt16 = 0x9
         public static let lineFeed: UInt16 = 0xA // \n
         public static let carriageReturn: UInt16 = 0xD // \r
+        public static let paragraphSeparator: UInt16 = 0x2029 // ¶
+        public static let lineSeparator: UInt16 = 0x2028 // line separator
     }
 }

--- a/Sources/CodeEditSourceEditor/InvisibleCharacters/InvisibleCharactersCoordinator.swift
+++ b/Sources/CodeEditSourceEditor/InvisibleCharacters/InvisibleCharactersCoordinator.swift
@@ -1,0 +1,103 @@
+//
+//  InvisibleCharactersCoordinator.swift
+//  CodeEditSourceEditor
+//
+//  Created by Khan Winter on 6/9/25.
+//
+
+import AppKit
+import CodeEditTextView
+
+/// Object that tells the text view how to draw invisible characters.
+///
+/// Takes a few parameters for contextual drawing such as the current editor theme, font, and indent option.
+///
+/// To keep lookups fast, does not use a computed property for ``InvisibleCharactersConfig/triggerCharacters``.
+/// Instead, this type keeps that internal property up-to-date whenever config is updated.
+///
+/// Another performance optimization is a cache mechanism in CodeEditTextView. Whenever the config, indent option,
+/// theme, or font are updated, this object will tell the text view to clear it's cache. Keep updates to a minimum to
+/// retain as much cached data as possible.
+final class InvisibleCharactersCoordinator: InvisibleCharactersDelegate {
+    var config: InvisibleCharactersConfig {
+        didSet {
+            triggerCharacters = config.triggerCharacters()
+        }
+    }
+    var indentOption: IndentOption
+    var theme: EditorTheme {
+        didSet {
+            invisibleColor = theme.invisibles.color
+            needsCacheClear = true
+        }
+    }
+    var font: NSFont {
+        didSet {
+            emphasizedFont = NSFontManager.shared.font(
+                withFamily: font.familyName ?? "",
+                traits: .unboldFontMask,
+                weight: 15, // Condensed
+                size: font.pointSize
+            ) ?? font
+            needsCacheClear = true
+        }
+    }
+
+    private var needsCacheClear = false
+    private var invisibleColor: NSColor
+    private var emphasizedFont: NSFont
+
+    /// The set of characters the text view should trigger a call to ``invisibleStyle`` for.
+    var triggerCharacters: Set<UInt16>
+
+    init(config: InvisibleCharactersConfig, indentOption: IndentOption, theme: EditorTheme, font: NSFont) {
+        self.config = config
+        self.indentOption = indentOption
+        self.theme = theme
+        self.font = font
+        triggerCharacters = config.triggerCharacters()
+        invisibleColor = theme.invisibles.color
+        emphasizedFont = NSFontManager.shared.font(
+            withFamily: font.familyName ?? "",
+            traits: .unboldFontMask,
+            weight: 15, // Condensed
+            size: font.pointSize
+        ) ?? font
+    }
+    
+    /// Determines if the textview should clear cached styles.
+    func invisibleStyleShouldClearCache() -> Bool {
+        if needsCacheClear {
+            needsCacheClear = false
+            return true
+        }
+        return false
+    }
+    
+    /// Determines the replacement style for a character found in a line fragment. Returns the style the text view
+    /// should use to emphasize or replace the character.
+    ///
+    /// Input is a unichar character (UInt16), and is compared to known characters. This method also emphasizes spaces
+    /// that appear on the same column user's selected indent width. The required font is expensive to compute
+    /// often and is cached in ``emphasizedFont``.
+    func invisibleStyle(for character: UInt16, at range: NSRange, lineRange: NSRange) -> InvisibleCharacterStyle? {
+        switch character {
+        case InvisibleCharactersConfig.Symbols.space:
+            guard config.showSpaces else { return nil }
+            let locationInLine = range.location - lineRange.location
+            let shouldBold = locationInLine % indentOption.charCount == indentOption.charCount - 1
+            return .replace(replacementCharacter: "·", color: invisibleColor, font: shouldBold ? emphasizedFont : font)
+        case InvisibleCharactersConfig.Symbols.tab:
+            guard config.showTabs else { return nil }
+            return .replace(replacementCharacter: "→", color: invisibleColor, font: font)
+        case InvisibleCharactersConfig.Symbols.carriageReturn, InvisibleCharactersConfig.Symbols.lineFeed:
+            guard config.showLineEndings else { return nil }
+            return .replace(replacementCharacter: "¬", color: invisibleColor, font: font)
+        default:
+            guard config.warningCharacters.contains(character) else {
+                return nil
+            }
+            return .emphasize(color: .systemRed.withAlphaComponent(0.3))
+        }
+    }
+}

--- a/Sources/CodeEditSourceEditor/InvisibleCharacters/InvisibleCharactersCoordinator.swift
+++ b/Sources/CodeEditSourceEditor/InvisibleCharacters/InvisibleCharactersCoordinator.swift
@@ -83,21 +83,68 @@ final class InvisibleCharactersCoordinator: InvisibleCharactersDelegate {
     func invisibleStyle(for character: UInt16, at range: NSRange, lineRange: NSRange) -> InvisibleCharacterStyle? {
         switch character {
         case InvisibleCharactersConfig.Symbols.space:
-            guard config.showSpaces else { return nil }
-            let locationInLine = range.location - lineRange.location
-            let shouldBold = locationInLine % indentOption.charCount == indentOption.charCount - 1
-            return .replace(replacementCharacter: "·", color: invisibleColor, font: shouldBold ? emphasizedFont : font)
+            return spacesStyle(range: range, lineRange: lineRange)
         case InvisibleCharactersConfig.Symbols.tab:
-            guard config.showTabs else { return nil }
-            return .replace(replacementCharacter: "→", color: invisibleColor, font: font)
-        case InvisibleCharactersConfig.Symbols.carriageReturn, InvisibleCharactersConfig.Symbols.lineFeed:
-            guard config.showLineEndings else { return nil }
-            return .replace(replacementCharacter: "¬", color: invisibleColor, font: font)
+            return tabStyle()
+        case InvisibleCharactersConfig.Symbols.carriageReturn:
+            return carriageReturnStyle()
+        case InvisibleCharactersConfig.Symbols.lineFeed:
+            return lineFeedStyle()
+        case InvisibleCharactersConfig.Symbols.paragraphSeparator:
+            return paragraphSeparatorStyle()
+        case InvisibleCharactersConfig.Symbols.lineSeparator:
+            return lineSeparatorStyle()
         default:
-            guard config.warningCharacters.contains(character) else {
-                return nil
-            }
-            return .emphasize(color: .systemRed.withAlphaComponent(0.3))
+            return warningCharacterStyle(for: character)
         }
+    }
+
+    private func spacesStyle(range: NSRange, lineRange: NSRange) -> InvisibleCharacterStyle? {
+        guard config.showSpaces else { return nil }
+        let locationInLine = range.location - lineRange.location
+        let shouldBold = locationInLine % indentOption.charCount == indentOption.charCount - 1
+        return .replace(
+            replacementCharacter: config.spaceReplacement,
+            color: invisibleColor,
+            font: shouldBold ? emphasizedFont : font
+        )
+    }
+
+    private func tabStyle() -> InvisibleCharacterStyle? {
+        guard config.showTabs else { return nil }
+        return .replace(replacementCharacter: config.tabReplacement, color: invisibleColor, font: font)
+    }
+
+    private func carriageReturnStyle() -> InvisibleCharacterStyle? {
+        guard config.showLineEndings else { return nil }
+        return .replace(replacementCharacter: config.carriageReturnReplacement, color: invisibleColor, font: font)
+    }
+
+    private func lineFeedStyle() -> InvisibleCharacterStyle? {
+        guard config.showLineEndings else { return nil }
+        return .replace(replacementCharacter: config.lineFeedReplacement, color: invisibleColor, font: font)
+    }
+
+    private func paragraphSeparatorStyle() -> InvisibleCharacterStyle? {
+        guard config.showLineEndings else { return nil }
+        return .replace(
+            replacementCharacter: config.paragraphSeparatorReplacement,
+            color: invisibleColor,
+            font: font
+        )
+    }
+
+    private func lineSeparatorStyle() -> InvisibleCharacterStyle? {
+        guard config.showLineEndings else { return nil }
+        return .replace(
+            replacementCharacter: config.lineSeparatorReplacement,
+            color: invisibleColor,
+            font: font
+        )
+    }
+
+    private func warningCharacterStyle(for character: UInt16) -> InvisibleCharacterStyle? {
+        guard config.warningCharacters.contains(character) else { return nil }
+        return .emphasize(color: .systemRed.withAlphaComponent(0.3))
     }
 }

--- a/Sources/CodeEditSourceEditor/InvisibleCharacters/InvisibleCharactersCoordinator.swift
+++ b/Sources/CodeEditSourceEditor/InvisibleCharacters/InvisibleCharactersCoordinator.swift
@@ -64,7 +64,7 @@ final class InvisibleCharactersCoordinator: InvisibleCharactersDelegate {
             size: font.pointSize
         ) ?? font
     }
-    
+
     /// Determines if the textview should clear cached styles.
     func invisibleStyleShouldClearCache() -> Bool {
         if needsCacheClear {
@@ -73,7 +73,7 @@ final class InvisibleCharactersCoordinator: InvisibleCharactersDelegate {
         }
         return false
     }
-    
+
     /// Determines the replacement style for a character found in a line fragment. Returns the style the text view
     /// should use to emphasize or replace the character.
     ///

--- a/Sources/CodeEditSourceEditor/Minimap/MinimapLineFragmentView.swift
+++ b/Sources/CodeEditSourceEditor/Minimap/MinimapLineFragmentView.swift
@@ -43,8 +43,8 @@ final class MinimapLineFragmentView: LineFragmentView {
 
     /// Set the new line fragment, and calculate drawing runs for drawing the fragment in the view.
     /// - Parameter newFragment: The new fragment to use.
-    override func setLineFragment(_ newFragment: LineFragment) {
-        super.setLineFragment(newFragment)
+    override func setLineFragment(_ newFragment: LineFragment, renderer: LineFragmentRenderer) {
+        super.setLineFragment(newFragment, renderer: renderer)
         guard let textStorage else { return }
 
         // Create the drawing runs using attribute information

--- a/Tests/CodeEditSourceEditorTests/Controller/TextViewControllerTests.swift
+++ b/Tests/CodeEditSourceEditorTests/Controller/TextViewControllerTests.swift
@@ -487,5 +487,77 @@ final class TextViewControllerTests: XCTestCase {
         lines = controller.getOverlappingLines(for: NSRange(location: 4, length: 1))
         XCTAssertEqual(2...2, lines)
     }
+
+    // MARK: - Invisible Characters
+
+    func test_setInvisibleCharacterConfig() {
+        controller.setText("     Hello world")
+        controller.indentOption = .spaces(count: 4)
+
+        XCTAssertEqual(controller.invisibleCharactersConfig, .empty)
+
+        controller.invisibleCharactersConfig = .init(showSpaces: true, showTabs: true, showLineEndings: true)
+        XCTAssertEqual(
+            controller.invisibleCharactersConfig,
+            .init(showSpaces: true, showTabs: true, showLineEndings: true)
+        )
+        XCTAssertEqual(
+            controller.invisibleCharactersCoordinator.config,
+            .init(showSpaces: true, showTabs: true, showLineEndings: true)
+        )
+
+        // Should emphasize the 4th space
+        XCTAssertEqual(
+            controller.invisibleCharactersCoordinator.invisibleStyle(
+                for: InvisibleCharactersConfig.Symbols.space,
+                at: NSRange(location: 3, length: 1),
+                lineRange: NSRange(location: 0, length: 15)
+            ),
+            .replace(
+                replacementCharacter: "·",
+                color: controller.theme.invisibles.color,
+                font: controller.invisibleCharactersCoordinator.emphasizedFont
+            )
+        )
+        XCTAssertEqual(
+            controller.invisibleCharactersCoordinator.invisibleStyle(
+                for: InvisibleCharactersConfig.Symbols.space,
+                at: NSRange(location: 4, length: 1),
+                lineRange: NSRange(location: 0, length: 15)
+            ),
+            .replace(
+                replacementCharacter: "·",
+                color: controller.theme.invisibles.color,
+                font: controller.font
+            )
+        )
+
+        if case .emphasize = controller.invisibleCharactersCoordinator.invisibleStyle(
+            for: InvisibleCharactersConfig.Symbols.tab,
+            at: .zero,
+            lineRange: .zero
+        ) {
+            XCTFail("Incorrect character style for invisible character")
+        }
+    }
+
+    // MARK: - Warning Characters
+
+    func test_setWarningCharacterConfig() {
+        XCTAssertEqual(controller.warningCharacters, [])
+
+        controller.warningCharacters = [0, 1]
+
+        XCTAssertEqual(controller.warningCharacters, [0, 1])
+        XCTAssertEqual(controller.invisibleCharactersCoordinator.warningCharacters, [0, 1])
+
+        if case .replace = controller.invisibleCharactersCoordinator.invisibleStyle(
+            for: 0,
+            at: .zero,
+            lineRange: .zero
+        ) {
+            XCTFail("Incorrect character style for warning character")
+        }
+    }
 }
 // swiftlint:enable all


### PR DESCRIPTION
### Description

Adds a configuration option to draw invisible characters. 

By default, draws spaces as a small dot, with emphasis on spaces that align with the user's selected indent width. Draws tabs as a small arrow. Draws line endings (carriage returns and line feeds) as a `¬` character.

Replacement characters are configurable using the config object.

Adds a configuration option to warn users about potentially dangerous/unnecessary characters that may not be visible to the naked eye. This could be used to warn about something like a zero-width space being accidentally copied into a file.

#### Detailed changes
- Adds a new `InvisibleCharactersConfig` type that contains toggles for certain whitespace characters, as well as a set of 'warning' characters to draw warning boxes on.
- Adds a new `InvisibleCharactersCoordinator` that tells the text view how to draw characters depending on the current configuration.
- Adds a new `invisibleCharacterConfig` option to `CodeEditSourceEditor` and `TextViewController`.
- Adds a new `warningCharacters` option to `CodeEditSourceEditor` and `TextViewController`.
- Updates `TextViewController` to correctly update the coordinator when the user's theme, font, or indent option are updated.

### Related Issues

* https://github.com/CodeEditApp/CodeEditTextView/issues/22
* #207 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Example document with tabs, spaces, newlines, and a zero-width character pasted in before the `1`. It responds to theme updates and live editing.

https://github.com/user-attachments/assets/29dc7585-c131-49a2-8ca8-afa2f3e2a554
