### PR TITLE
Ensure Coordinator's Lifetime is Equal To The Editor's

### DIFF
--- a/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -230,6 +230,7 @@ public class TextViewController: NSViewController {
         coordinators.forEach {
             $0.prepareCoordinator(controller: self)
         }
+        self.textCoordinators = coordinators.map { WeakCoordinator($0) }
     }
 
     required init?(coder: NSCoder) {

--- a/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor.swift
+++ b/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor.swift
@@ -128,9 +128,6 @@ public struct SourceEditor: NSViewControllerRepresentable {
             context.coordinator.isUpdateFromTextView = false
         }
 
-        // Set this no matter what to avoid having to compare object pointers.
-        controller.textCoordinators = coordinators.map { WeakCoordinator($0) }
-
         // Do manual diffing to reduce the amount of reloads.
         // This helps a lot in view performance, as it otherwise gets triggered on each environment change.
         guard !paramsAreEqual(controller: controller, coordinator: context.coordinator) else {


### PR DESCRIPTION
### Description

Guarantees that all text coordinator's lifetimes match that of the editor's.

### Related Issues

* https://github.com/CodeEditApp/CodeEdit/pull/2058

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

