### PR TITLE
Fix Broken Documentation Links

### DIFF
--- a/Sources/CodeEditSourceEditor/Documentation.docc/Documentation.md
+++ b/Sources/CodeEditSourceEditor/Documentation.docc/Documentation.md
@@ -1,4 +1,4 @@
-# ``SourceEditor``
+# ``CodeEditSourceEditor``
 
 A code editor with syntax highlighting powered by tree-sitter. 
 
@@ -34,8 +34,9 @@ Licensed under the [MIT license](https://github.com/CodeEditApp/CodeEdit/blob/ma
 
 ### Text View
 
-- ``SourceEditor`` The SwiftUI API for the source editor.
-- ``SourceEditorConfiguration`` Customize the source editor's behavior, layout, appearance, etc.
+- <doc:SourceEditor> The SwiftUI API for the source editor.
+- ``SourceEditorConfiguration`` Customize the source editor's behavior, layout, appearance, and more.
+- ``SourceEditorState`` Listen to the current state of the editor. Cursor positions, scroll positions, and more.
 - ``TextViewController`` The AppKit view controller for the source editor.
 - ``GutterView`` A view used to display line numbers and folding regions.
 

--- a/Sources/CodeEditSourceEditor/Documentation.docc/SourceEditor.md
+++ b/Sources/CodeEditSourceEditor/Documentation.docc/SourceEditor.md
@@ -1,4 +1,4 @@
-# ``SourceEditor``
+# Source Editor
 
 ## Usage
 

--- a/Sources/CodeEditSourceEditor/SourceEditorConfiguration/SourceEditorConfiguration.swift
+++ b/Sources/CodeEditSourceEditor/SourceEditorConfiguration/SourceEditorConfiguration.swift
@@ -31,11 +31,11 @@ import AppKit
 ///   - The category initializer.
 ///   - The passthrough variable in `TextViewController`.
 
-/// Configuration object for the ``SourceEditor``. Determines appearance, behavior, layout and what features are
+/// Configuration object for the <doc:SourceEditor>. Determines appearance, behavior, layout and what features are
 /// enabled (peripherals).
 ///
 /// To update the configuration, update the ``TextViewController/configuration`` property, or pass a value to the
-/// ``SourceEditor`` SwiftUI API. Both methods will call the `didSetOnController` method on this type, which will
+/// <doc:SourceEditor> SwiftUI API. Both methods will call the `didSetOnController` method on this type, which will
 /// update the text controller as necessary for the new configuration.
 public struct SourceEditorConfiguration: Equatable {
     /// Configure the appearance of the editor. Font, theme, line height, etc.

--- a/Sources/CodeEditSourceEditor/TextViewCoordinator/TextViewCoordinator.swift
+++ b/Sources/CodeEditSourceEditor/TextViewCoordinator/TextViewCoordinator.swift
@@ -7,10 +7,11 @@
 
 import AppKit
 
-/// A protocol that can be used to receive extra state change messages from ``SourceEditor``.
+/// A protocol that can be used to receive extra state change messages from <doc:SourceEditor>.
 ///
 /// These are used as a way to push messages up from underlying components into SwiftUI land without requiring passing
-/// callbacks for each message to the ``SourceEditor`` initializer.
+/// callbacks for each message to the
+/// ``SourceEditor/init(_:language:configuration:state:highlightProviders:undoManager:coordinators:)`` initializer.
 ///
 /// They're very useful for updating UI that is directly related to the state of the editor, such as the current
 /// cursor position. For an example, see the ``CombineCoordinator`` class, which implements combine publishers for the


### PR DESCRIPTION
Fix some broken links, specifically linking to the doc file for the source editor struct and fixing the homepage for the documentation site.