### PR TITLE
Fix Style Store Crash

### DIFF
--- a/Sources/CodeEditSourceEditor/Highlighting/StyledRangeContainer/StyledRangeContainer.swift
+++ b/Sources/CodeEditSourceEditor/Highlighting/StyledRangeContainer/StyledRangeContainer.swift
@@ -123,11 +123,6 @@ class StyledRangeContainer {
         var minValue = allRuns.compactMap { $0.last }.enumerated().min(by: { $0.1.length < $1.1.length })
 
         while let value = minValue {
-            // Early return if all arrays are empty
-            guard allRuns.contains(where: { !$0.isEmpty }) else {
-                return runs.reversed()
-            }
-
             // Get minimum length off the end of each array
             let minRunIdx = value.offset
             var minRun = value.element
@@ -148,7 +143,9 @@ class StyledRangeContainer {
                 }
             }
 
-            allRuns[minRunIdx].removeLast()
+            if !allRuns[minRunIdx].isEmpty {
+                allRuns[minRunIdx].removeLast()
+            }
 
             runs.append(minRun)
             minValue = allRuns.compactMap { $0.last }.enumerated().min(by: { $0.1.length < $1.1.length })

--- a/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor.swift
+++ b/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor.swift
@@ -149,7 +149,8 @@ public struct SourceEditor: NSViewControllerRepresentable {
             controller.setCursorPositions(cursorPositions)
         }
 
-        if let scrollPosition = state.scrollPosition, scrollPosition != state.scrollPosition {
+        let scrollView = controller.scrollView
+        if let scrollPosition = state.scrollPosition, scrollPosition != scrollView?.contentView.bounds.origin {
             controller.scrollView.scroll(controller.scrollView.contentView, to: scrollPosition)
             controller.scrollView.reflectScrolledClipView(controller.scrollView.contentView)
             controller.gutterView.needsDisplay = true


### PR DESCRIPTION
### Description

Fixes a crash when the styled range store has empty arrays and still tries to remove values.

### Related Issues

N/A

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A