### PR TITLE
Remove Unnecessary `completionTriggerCharacters` Configuration

### DIFF
--- a/Sources/CodeEditSourceEditor/CodeSuggestion/Model/SuggestionTriggerCharacterModel.swift
+++ b/Sources/CodeEditSourceEditor/CodeSuggestion/Model/SuggestionTriggerCharacterModel.swift
@@ -15,18 +15,17 @@ import TextStory
 /// Was originally a `TextFilter` model, however those are called before text is changed and cursors are updated.
 /// The suggestion model expects up-to-date cursor positions as well as complete text contents. This being
 /// essentially a textview delegate ensures both of those promises are upheld.
+@MainActor
 final class SuggestionTriggerCharacterModel {
     weak var controller: TextViewController?
     private var lastPosition: NSRange?
 
-    var triggerCharacters: Set<String>? {
-        controller?.configuration.peripherals.codeSuggestionTriggerCharacters
-    }
-
     func textView(_ textView: TextView, didReplaceContentsIn range: NSRange, with string: String) {
-        guard let controller, let completionDelegate = controller.completionDelegate, let triggerCharacters else {
+        guard let controller, let completionDelegate = controller.completionDelegate else {
             return
         }
+
+        let triggerCharacters = completionDelegate.completionTriggerCharacters()
 
         let mutation = TextMutation(
             string: string,

--- a/Sources/CodeEditSourceEditor/SourceEditorConfiguration/SourceEditorConfiguration+Peripherals.swift
+++ b/Sources/CodeEditSourceEditor/SourceEditorConfiguration/SourceEditorConfiguration+Peripherals.swift
@@ -28,16 +28,13 @@ extension SourceEditorConfiguration {
         /// non-standard quote character: `“ (0x201C)`.
         public var warningCharacters: Set<UInt16>
 
-        public var codeSuggestionTriggerCharacters: Set<String>
-
         public init(
             showGutter: Bool = true,
             showMinimap: Bool = true,
             showReformattingGuide: Bool = false,
             showFoldingRibbon: Bool = true,
             invisibleCharactersConfiguration: InvisibleCharactersConfiguration = .empty,
-            warningCharacters: Set<UInt16> = [],
-            codeSuggestionTriggerCharacters: Set<String> = []
+            warningCharacters: Set<UInt16> = []
         ) {
             self.showGutter = showGutter
             self.showMinimap = showMinimap
@@ -45,7 +42,6 @@ extension SourceEditorConfiguration {
             self.showFoldingRibbon = showFoldingRibbon
             self.invisibleCharactersConfiguration = invisibleCharactersConfiguration
             self.warningCharacters = warningCharacters
-            self.codeSuggestionTriggerCharacters = codeSuggestionTriggerCharacters
         }
 
         @MainActor
@@ -82,10 +78,6 @@ extension SourceEditorConfiguration {
             if shouldUpdateInsets && controller.scrollView != nil { // Check for view existence
                 controller.updateContentInsets()
                 controller.updateTextInsets()
-            }
-
-            if oldConfig?.codeSuggestionTriggerCharacters != codeSuggestionTriggerCharacters {
-                controller.setUpTextFormation()
             }
         }
     }


### PR DESCRIPTION
Removes an unnecessary configuration parameter that was a duplicate of the more flexible delegate method.