### PR TITLE
Fix code completion window visibility issues

### DIFF
--- a/Sources/CodeEditSourceEditor/CodeSuggestion/Window/SuggestionController+Window.swift
+++ b/Sources/CodeEditSourceEditor/CodeSuggestion/Window/SuggestionController+Window.swift
@@ -84,7 +84,7 @@ extension SuggestionController {
     static func makeWindow() -> NSWindow {
         let window = NSWindow(
             contentRect: .zero,
-            styleMask: [.resizable, .fullSizeContentView, .nonactivatingPanel, .utilityWindow],
+            styleMask: [.borderless],
             backing: .buffered,
             defer: false
         )
@@ -97,8 +97,10 @@ extension SuggestionController {
         window.hasShadow = true
         window.isOpaque = false
         window.tabbingMode = .disallowed
-        window.hidesOnDeactivate = true
+        window.hidesOnDeactivate = false
         window.backgroundColor = .clear
+        window.canHide = false
+        window.acceptsMouseMovedEvents = true
 
         return window
     }

--- a/Sources/CodeEditSourceEditor/CodeSuggestion/Window/SuggestionController.swift
+++ b/Sources/CodeEditSourceEditor/CodeSuggestion/Window/SuggestionController.swift
@@ -103,7 +103,10 @@ public final class SuggestionController: NSWindowController {
     /// Opens the window as a child of another window.
     public func showWindow(attachedTo parentWindow: NSWindow) {
         guard let window = window else { return }
+
+        super.showWindow(nil)
         parentWindow.addChildWindow(window, ordered: .above)
+        window.orderFront(nil)
 
         // Close on window switch observer
         // Initialized outside of `setupEventMonitors` in order to grab the parent window
@@ -118,8 +121,6 @@ public final class SuggestionController: NSWindowController {
             self?.close()
         }
 
-        super.showWindow(nil)
-        window.orderFront(nil)
         window.contentViewController?.viewWillAppear()
     }
 
@@ -132,6 +133,12 @@ public final class SuggestionController: NSWindowController {
             popover = nil
         } else {
             contentViewController?.viewWillDisappear()
+        }
+
+        // Clean up window observers
+        if let observer = windowResignObserver {
+            NotificationCenter.default.removeObserver(observer)
+            windowResignObserver = nil
         }
 
         super.close()

--- a/Sources/CodeEditSourceEditor/SupportingViews/BezelNotification.swift
+++ b/Sources/CodeEditSourceEditor/SupportingViews/BezelNotification.swift
@@ -51,7 +51,7 @@ final class BezelNotification {
 
         let window = NSPanel(
             contentRect: .zero,
-            styleMask: [.borderless, .nonactivatingPanel, .hudWindow],
+            styleMask: [.borderless, .hudWindow],
             backing: .buffered,
             defer: true
         )

--- a/Sources/CodeEditSourceEditor/SupportingViews/BezelNotification.swift
+++ b/Sources/CodeEditSourceEditor/SupportingViews/BezelNotification.swift
@@ -51,7 +51,7 @@ final class BezelNotification {
 
         let window = NSPanel(
             contentRect: .zero,
-            styleMask: [.borderless, .hudWindow],
+            styleMask: [.borderless, .nonactivatingPanel, .hudWindow],
             backing: .buffered,
             defer: true
         )


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/6a9ad280-54e0-4bcc-b015-6fc8a22e0660


Fixes intermittent visibility problems where the code completion window would not appear visually despite functioning correctly for keyboard navigation.

Fixes #351 



## Changes Made

- **Window Style Mask**: Replaced problematic `.nonactivatingPanel` and `.utilityWindow` with `.borderless`
- **Window Hiding Behavior**: Changed `hidesOnDeactivate` from `true` to `false` 
- **Window Properties**: Added `canHide = false` and `acceptsMouseMovedEvents = true`
- **Window Ordering**: Improved window showing sequence in `showWindow(attachedTo:)`
- **Resource Cleanup**: Added proper cleanup of notification observers in `close()`

## Root Cause

The `.nonactivatingPanel` style mask was preventing the window from becoming key, which caused:
- The console warning: `canBecomeKeyWindow returned NO`
- Inconsistent window visibility despite functional keyboard navigation

## Solution

Using `.borderless` provides the clean appearance needed for code completion while ensuring reliable window display. This style mask is ideal for popover-style UI elements as it gives full control over positioning and appearance without the activation issues.

## Test Plan

- [x] Code completion window appears consistently when triggered
- [x] Keyboard navigation (up/down arrows, Tab, Escape) works correctly
- [x] Window positioning and sizing work as expected
- [x] No more `canBecomeKeyWindow` console warnings
- [x] Window closes properly when focus is lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)