### PR TITLE
Fix macOS 13 compatibility

### DIFF
--- a/Sources/CodeEditSourceEditor/Extensions/DispatchQueue+dispatchMainIfNot.swift
+++ b/Sources/CodeEditSourceEditor/Extensions/DispatchQueue+dispatchMainIfNot.swift
@@ -31,7 +31,7 @@ extension DispatchQueue {
         if Thread.isMainThread {
             return item()
         } else {
-            return DispatchQueue.main.asyncAndWait(execute: item)
+            return DispatchQueue.main.sync(execute: item)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace `asyncAndWait` with `sync` to fix crash on macOS 13

## Problem
`DispatchQueue.asyncAndWait(execute:)` is only available on macOS 14+. Using `#available` check doesn't help because the symbol is still hard-linked in the binary, causing dyld to crash at launch on older systems:

```
Symbol not found: _$sSo17OS_dispatch_queueC8DispatchE12asyncAndWait7executexxyKXE_tKlF
Expected in: /usr/lib/swift/libswiftDispatch.dylib
```

## Solution
Use `DispatchQueue.main.sync(execute:)` instead, which has equivalent behavior and is available on all macOS versions.