### PR TITLE
Fix markdown syntax highlighting by mapping capture names

### DIFF
--- a/Sources/CodeEditSourceEditor/Enums/CaptureName.swift
+++ b/Sources/CodeEditSourceEditor/Enums/CaptureName.swift
@@ -92,6 +92,18 @@ public enum CaptureName: Int8, CaseIterable, Sendable {
             return .keywordReturn
         case "keyword.function":
             return .keywordFunction
+        case "text.title", "text.strong", "punctuation.special":
+            return .keyword
+        case "text.literal", "text.uri", "string.escape":
+            return .string
+        case "text.reference":
+            return .type
+        case "text.emphasis":
+            return .variable
+        case "punctuation.delimiter":
+            return .comment
+        case "none":
+            return nil
         default:
             return nil
         }


### PR DESCRIPTION
### Description

The markdown tree-sitter grammar uses nvim-treesitter capture names (e.g. text.title, punctuation.special) that CaptureName.fromString() didn't recognize, causing all markdown highlights to be silently dropped.

Map these to existing CaptureName cases so no new enum values or theme changes are needed.

### Related Issues

* Fixes #286

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<img width="2024" height="1124" alt="CleanShot 2026-03-14 at 22 23 43@2x" src="https://github.com/user-attachments/assets/28936b6c-215c-45f2-8047-67db4afa94ff" />
